### PR TITLE
Fix past events visible after progress & wrong today section with multi-day event

### DIFF
--- a/Calendr.xcodeproj/project.pbxproj
+++ b/Calendr.xcodeproj/project.pbxproj
@@ -17,6 +17,8 @@
 		34273C0825E1A56200B35091 /* SegoeUISymbol.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 34F96CD725B4E2F50020DEEA /* SegoeUISymbol.ttf */; };
 		34286E4625D5CD9C0097EC5D /* WeekNumberCellView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34286E4525D5CD9C0097EC5D /* WeekNumberCellView.swift */; };
 		34305BCB25992A4E00AB381D /* Rx+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34305BCA25992A4E00AB381D /* Rx+Helpers.swift */; };
+		3430675E25F6BC15000D4003 /* HistoricalSchedulerTimeConverter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3430675D25F6BC15000D4003 /* HistoricalSchedulerTimeConverter.swift */; };
+		3430676325F6C130000D4003 /* TrackedHistoricalScheduler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3430676225F6C130000D4003 /* TrackedHistoricalScheduler.swift */; };
 		3430ED03259634E00045DA53 /* NSStackView+Rx.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3430ED02259634E00045DA53 /* NSStackView+Rx.swift */; };
 		3449402E25C348B20020E664 /* GeneralSettingsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3449402D25C348B20020E664 /* GeneralSettingsViewController.swift */; };
 		3449403225C348C70020E664 /* CalendarPickerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3449403125C348C70020E664 /* CalendarPickerViewController.swift */; };
@@ -57,7 +59,7 @@
 		349355A625BCA8D400957945 /* EventListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 349355A525BCA8D400957945 /* EventListView.swift */; };
 		349355AA25BCA8DF00957945 /* EventView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 349355A925BCA8DF00957945 /* EventView.swift */; };
 		349355B225BCB07B00957945 /* EventViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 349355B125BCB07B00957945 /* EventViewModel.swift */; };
-		349E4CEF25CF48ED00A6FC18 /* HistoricalScheduler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 349E4CEE25CF48ED00A6FC18 /* HistoricalScheduler.swift */; };
+		349E4CEF25CF48ED00A6FC18 /* VirtualTimeScheduler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 349E4CEE25CF48ED00A6FC18 /* VirtualTimeScheduler.swift */; };
 		34A4C3E925963FB200D0F949 /* NSStackView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34A4C3E825963FB200D0F949 /* NSStackView.swift */; };
 		34A6434D25F42375000A0F08 /* EventViewPreview.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34A6434C25F42375000A0F08 /* EventViewPreview.swift */; };
 		34A6435325F45495000A0F08 /* Fonts.generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34A6435225F45495000A0F08 /* Fonts.generated.swift */; };
@@ -112,6 +114,8 @@
 		3421AD3C25BA1D0800A4F468 /* SettingsViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsViewModelTests.swift; sourceTree = "<group>"; };
 		34286E4525D5CD9C0097EC5D /* WeekNumberCellView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeekNumberCellView.swift; sourceTree = "<group>"; };
 		34305BCA25992A4E00AB381D /* Rx+Helpers.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Rx+Helpers.swift"; sourceTree = "<group>"; };
+		3430675D25F6BC15000D4003 /* HistoricalSchedulerTimeConverter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HistoricalSchedulerTimeConverter.swift; sourceTree = "<group>"; };
+		3430676225F6C130000D4003 /* TrackedHistoricalScheduler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrackedHistoricalScheduler.swift; sourceTree = "<group>"; };
 		3430ED02259634E00045DA53 /* NSStackView+Rx.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSStackView+Rx.swift"; sourceTree = "<group>"; };
 		3449402D25C348B20020E664 /* GeneralSettingsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GeneralSettingsViewController.swift; sourceTree = "<group>"; };
 		3449403125C348C70020E664 /* CalendarPickerViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarPickerViewController.swift; sourceTree = "<group>"; };
@@ -161,7 +165,7 @@
 		349355A525BCA8D400957945 /* EventListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventListView.swift; sourceTree = "<group>"; };
 		349355A925BCA8DF00957945 /* EventView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventView.swift; sourceTree = "<group>"; };
 		349355B125BCB07B00957945 /* EventViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventViewModel.swift; sourceTree = "<group>"; };
-		349E4CEE25CF48ED00A6FC18 /* HistoricalScheduler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HistoricalScheduler.swift; sourceTree = "<group>"; };
+		349E4CEE25CF48ED00A6FC18 /* VirtualTimeScheduler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VirtualTimeScheduler.swift; sourceTree = "<group>"; };
 		34A4C3E825963FB200D0F949 /* NSStackView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NSStackView.swift; sourceTree = "<group>"; };
 		34A6434C25F42375000A0F08 /* EventViewPreview.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EventViewPreview.swift; sourceTree = "<group>"; };
 		34A6435225F45495000A0F08 /* Fonts.generated.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Fonts.generated.swift; sourceTree = "<group>"; };
@@ -280,9 +284,18 @@
 				34651F6525E314A900518C5A /* CalendarModel.swift */,
 				34924CE7259FCC95009C3450 /* Date.swift */,
 				34F88A8025B0C6A3005C9BA6 /* EventModel.swift */,
-				349E4CEE25CF48ED00A6FC18 /* HistoricalScheduler.swift */,
 			);
 			path = Extensions;
+			sourceTree = "<group>";
+		};
+		3430676125F6C117000D4003 /* Schedulers */ = {
+			isa = PBXGroup;
+			children = (
+				3430675D25F6BC15000D4003 /* HistoricalSchedulerTimeConverter.swift */,
+				3430676225F6C130000D4003 /* TrackedHistoricalScheduler.swift */,
+				349E4CEE25CF48ED00A6FC18 /* VirtualTimeScheduler.swift */,
+			);
+			path = Schedulers;
 			sourceTree = "<group>";
 		};
 		347D0F8B25952F89002451EC = {
@@ -343,6 +356,7 @@
 				341B2B4125D0B19500336342 /* StatusItemViewModelTests.swift */,
 				34305C3025994D4500AB381D /* Extensions */,
 				348E703A25C617DD00B3B160 /* Mocks */,
+				3430676125F6C117000D4003 /* Schedulers */,
 			);
 			path = CalendrTests;
 			sourceTree = "<group>";
@@ -768,15 +782,17 @@
 			buildActionMask = 2147483647;
 			files = (
 				348E703C25C617F100B3B160 /* MockDateProvider.swift in Sources */,
+				3430675E25F6BC15000D4003 /* HistoricalSchedulerTimeConverter.swift in Sources */,
 				34C72F8425E88B6600FD20FA /* MockStatusItemSettings.swift in Sources */,
 				34E1902325B76CFE00E9491B /* CalendarPickerViewModelTests.swift in Sources */,
 				34924CE8259FCC95009C3450 /* Date.swift in Sources */,
 				34924CD6259FB814009C3450 /* CalendarExtensionTests.swift in Sources */,
 				34A9513125D9C14500D1B2CA /* Calendar.swift in Sources */,
+				3430676325F6C130000D4003 /* TrackedHistoricalScheduler.swift in Sources */,
 				34651F6E25E3171D00518C5A /* EventViewModelLinkTests.swift in Sources */,
 				3421AD3D25BA1D0800A4F468 /* SettingsViewModelTests.swift in Sources */,
 				34651F7A25E325EA00518C5A /* MockWorkspaceServiceProvider.swift in Sources */,
-				349E4CEF25CF48ED00A6FC18 /* HistoricalScheduler.swift in Sources */,
+				349E4CEF25CF48ED00A6FC18 /* VirtualTimeScheduler.swift in Sources */,
 				34924CE4259FCB36009C3450 /* DateSelectorTests.swift in Sources */,
 				34C72F8C25E88DA100FD20FA /* MockCalendarSettings.swift in Sources */,
 				34651F6625E314A900518C5A /* CalendarModel.swift in Sources */,

--- a/Calendr/Events/EventListViewModel.swift
+++ b/Calendr/Events/EventListViewModel.swift
@@ -129,7 +129,7 @@ class EventListViewModel {
 
                         return [eventItem]
                     }
-                    .flatMap { $0 }
+                    .flatten()
 
                 guard allDayViewModels.isEmpty else {
                     return [.section(Strings.Formatter.Date.allDay)] + allDayViewModels + viewModels

--- a/Calendr/Events/EventListViewModel.swift
+++ b/Calendr/Events/EventListViewModel.swift
@@ -74,7 +74,7 @@ class EventListViewModel {
                         !$0.isAllDay && endsToday($0)
                     }
                     .map {
-                        Int(dateProvider.now.distance(to: $0.end).rounded(.up))
+                        Int(dateProvider.now.distance(to: $0.end).rounded(.up)) + 1
                     }
                     .filter { $0 >= 0 }
                     .map {

--- a/Calendr/Events/EventViewModel.swift
+++ b/Calendr/Events/EventViewModel.swift
@@ -100,7 +100,7 @@ class EventViewModel {
 
         let total = event.start.distance(to: event.end)
         let secondsToStart = Int(dateProvider.now.distance(to: event.start))
-        let secondsToEnd = Int(dateProvider.now.distance(to: event.end).rounded(.up))
+        let secondsToEnd = Int(dateProvider.now.distance(to: event.end).rounded(.up)) + 1
 
         let isPast: Observable<Bool>
         let clock: Observable<Void>
@@ -137,7 +137,7 @@ class EventViewModel {
                 guard
                     ellapsed >= 0,
                     dateProvider.calendar.isDate(
-                        dateProvider.now, lessThan: event.end, granularity: .second
+                        dateProvider.now, lessThanOrEqualTo: event.end, granularity: .second
                     )
                 else { return nil }
 

--- a/Calendr/Extensions/Rx+Helpers.swift
+++ b/Calendr/Extensions/Rx+Helpers.swift
@@ -21,6 +21,10 @@ extension ObservableType {
     func matching(_ value: Element) -> Observable<Element> where Element: Equatable {
         filter { value ~= $0 }
     }
+
+    func skipNil<T>() -> Observable<T> where Element == T? {
+        compactMap { $0 }
+    }
 }
 
 extension PublishSubject {

--- a/Calendr/Extensions/Sequence.swift
+++ b/Calendr/Extensions/Sequence.swift
@@ -17,7 +17,11 @@ extension Sequence {
         }
     }
 
-    func compactMap<T>() -> [T] where Element == T? {
+    func compact<T>() -> [T] where Element == T? {
         compactMap { $0 }
+    }
+
+    func flatten() -> [Element.Element] where Element: Sequence {
+        flatMap { $0 }
     }
 }

--- a/Calendr/Main/MainViewController.swift
+++ b/Calendr/Main/MainViewController.swift
@@ -110,6 +110,7 @@ class MainViewController: NSViewController {
             .distinctUntilChanged()
 
         eventListViewModel = EventListViewModel(
+            dateObservable: selectedDate,
             eventsObservable: eventsObservable,
             dateProvider: dateProvider,
             workspace: workspace,

--- a/Calendr/MenuBar/NextEventViewModel.swift
+++ b/Calendr/MenuBar/NextEventViewModel.swift
@@ -52,17 +52,17 @@ class NextEventViewModel {
             .share()
 
         barColor = nextEventObservable
-            .compactMap { $0 }
+            .skipNil()
             .map(\.event.calendar.color)
             .distinctUntilChanged()
 
         backgroundColor = nextEventObservable
-            .compactMap { $0 }
+            .skipNil()
             .map { $0.isInProgress ? $0.event.calendar.color.copy(alpha: 0.2)!: .clear }
             .distinctUntilChanged()
         
         title = nextEventObservable
-            .compactMap { $0 }
+            .skipNil()
             .map(\.event.title)
             .distinctUntilChanged()
 
@@ -72,7 +72,7 @@ class NextEventViewModel {
         dateFormatter.maximumUnitCount = 2
 
         time = nextEventObservable
-            .compactMap { $0 }
+            .skipNil()
             .map { [dateProvider] event, isInProgress in
 
                 dateFormatter.allowedUnits = [.hour, .minute]

--- a/Calendr/Providers/WorkspaceServiceProvider.swift
+++ b/Calendr/Providers/WorkspaceServiceProvider.swift
@@ -30,7 +30,7 @@ extension WorkspaceServiceProviding {
 
         let detector = try! NSDataDetector(types: NSTextCheckingResult.CheckingType.link.rawValue)
 
-        return texts.compactMap().flatMap { text in
+        return texts.compact().flatMap { text in
             detector
                 .matches(in: text, options: [], range: NSRange(location: 0, length: text.count))
                 .filter { text[Range($0.range, in: text)!].contains("://") }

--- a/CalendrTests/EventListViewModelTests.swift
+++ b/CalendrTests/EventListViewModelTests.swift
@@ -270,7 +270,7 @@ class EventListViewModelTests: XCTestCase {
         settings.togglePastEvents.onNext(false)
 
         XCTAssertFalse(scheduler.log.isEmpty)
-        XCTAssertEqual(scheduler.log, events.filter(\.isAllDay.isFalse).map(\.end))
+        XCTAssertTrue(zip(scheduler.log, events.filter(\.isAllDay.isFalse).map(\.end)).allSatisfy(>))
     }
 
     func testEventList_withHidePastEventsEnabled_withPartialSecond_shouldScheduleRefreshesCorrectly() {
@@ -285,6 +285,6 @@ class EventListViewModelTests: XCTestCase {
         settings.togglePastEvents.onNext(false)
 
         XCTAssertFalse(scheduler.log.isEmpty)
-        XCTAssertTrue(zip(scheduler.log, events.filter(\.isAllDay.isFalse).map(\.end)).allSatisfy(>=))
+        XCTAssertTrue(zip(scheduler.log, events.filter(\.isAllDay.isFalse).map(\.end)).allSatisfy(>))
     }
 }

--- a/CalendrTests/EventViewModelProgressTests.swift
+++ b/CalendrTests/EventViewModelProgressTests.swift
@@ -218,8 +218,13 @@ class EventViewModelProgressTests: XCTestCase {
         scheduler.advance(.seconds(1))
         XCTAssertEqual(progress, 0.2)
 
-        // event finished
+        // 100% progress
         dateProvider.now = .make(year: 2021, month: 1, day: 1, hour: 15)
+        scheduler.advance(.seconds(1))
+        XCTAssertEqual(progress, 1)
+
+        // event finished
+        dateProvider.add(1, .second)
         scheduler.advance(.seconds(1))
         XCTAssertNil(progress)
     }

--- a/CalendrTests/EventViewModelProgressTests.swift
+++ b/CalendrTests/EventViewModelProgressTests.swift
@@ -27,7 +27,7 @@ class EventViewModelProgressTests: XCTestCase {
             isAllDay: true
         )
 
-        var progress: CGFloat?
+        var progress: CGFloat? = -1
 
         viewModel.progress
             .bind { progress = $0 }
@@ -45,7 +45,7 @@ class EventViewModelProgressTests: XCTestCase {
             end: .make(year: 2021, month: 1, day: 2, hour: 15)
         )
 
-        var progress: CGFloat?
+        var progress: CGFloat? = -1
 
         viewModel.progress
             .bind { progress = $0 }
@@ -63,7 +63,7 @@ class EventViewModelProgressTests: XCTestCase {
             end: .make(year: 2021, month: 1, day: 1, hour: 15)
         )
 
-        var progress: CGFloat?
+        var progress: CGFloat? = -1
 
         viewModel.progress
             .bind { progress = $0 }
@@ -81,7 +81,7 @@ class EventViewModelProgressTests: XCTestCase {
             end: .make(year: 2021, month: 1, day: 1, hour: 15)
         )
 
-        var progress: CGFloat?
+        var progress: CGFloat? = -1
 
         viewModel.progress
             .bind { progress = $0 }
@@ -99,7 +99,7 @@ class EventViewModelProgressTests: XCTestCase {
             end: .make(year: 2021, month: 1, day: 1, hour: 15)
         )
 
-        var progress: CGFloat?
+        var progress: CGFloat? = -1
 
         viewModel.progress
             .bind { progress = $0 }
@@ -193,7 +193,7 @@ class EventViewModelProgressTests: XCTestCase {
             scheduler: scheduler
         )
 
-        var progress: CGFloat?
+        var progress: CGFloat? = -1
 
         viewModel.progress
             .bind { progress = $0 }
@@ -218,13 +218,8 @@ class EventViewModelProgressTests: XCTestCase {
         scheduler.advance(.seconds(1))
         XCTAssertEqual(progress, 0.2)
 
-        // 100% progress
-        dateProvider.now = .make(year: 2021, month: 1, day: 1, hour: 15)
-        scheduler.advance(.seconds(1))
-        XCTAssertEqual(progress, 1)
-
         // event finished
-        dateProvider.now += 1
+        dateProvider.now = .make(year: 2021, month: 1, day: 1, hour: 15)
         scheduler.advance(.seconds(1))
         XCTAssertNil(progress)
     }

--- a/CalendrTests/Schedulers/HistoricalSchedulerTimeConverter.swift
+++ b/CalendrTests/Schedulers/HistoricalSchedulerTimeConverter.swift
@@ -1,0 +1,68 @@
+//
+//  HistoricalSchedulerTimeConverter.swift
+//  CalendrTests
+//
+//  Created by Paker on 08/03/2021.
+//
+// 💡 This is just a copy from RxSwift because it doesn't have a public constructor ¯\_(ツ)_/¯
+//
+
+import RxSwift
+
+/// Converts historical virtual time into real time.
+///
+/// Since historical virtual time is also measured in `Date`, this converter is identity function.
+public struct HistoricalSchedulerTimeConverter : VirtualTimeConverterType {
+    /// Virtual time unit used that represents ticks of virtual clock.
+    public typealias VirtualTimeUnit = RxTime
+
+    /// Virtual time unit used to represent differences of virtual times.
+    public typealias VirtualTimeIntervalUnit = TimeInterval
+
+    /// Returns identical value of argument passed because historical virtual time is equal to real time, just
+    /// decoupled from local machine clock.
+    public func convertFromVirtualTime(_ virtualTime: VirtualTimeUnit) -> RxTime {
+        virtualTime
+    }
+
+    /// Returns identical value of argument passed because historical virtual time is equal to real time, just
+    /// decoupled from local machine clock.
+    public func convertToVirtualTime(_ time: RxTime) -> VirtualTimeUnit {
+        time
+    }
+
+    /// Returns identical value of argument passed because historical virtual time is equal to real time, just
+    /// decoupled from local machine clock.
+    public func convertFromVirtualTimeInterval(_ virtualTimeInterval: VirtualTimeIntervalUnit) -> TimeInterval {
+        virtualTimeInterval
+    }
+
+    /// Returns identical value of argument passed because historical virtual time is equal to real time, just
+    /// decoupled from local machine clock.
+    public func convertToVirtualTimeInterval(_ timeInterval: TimeInterval) -> VirtualTimeIntervalUnit {
+        timeInterval
+    }
+
+    /**
+     Offsets `Date` by time interval.
+
+     - parameter time: Time.
+     - parameter timeInterval: Time interval offset.
+     - returns: Time offsetted by time interval.
+    */
+    public func offsetVirtualTime(_ time: VirtualTimeUnit, offset: VirtualTimeIntervalUnit) -> VirtualTimeUnit {
+        time.addingTimeInterval(offset)
+    }
+
+    /// Compares two `Date`s.
+    public func compareVirtualTime(_ lhs: VirtualTimeUnit, _ rhs: VirtualTimeUnit) -> VirtualTimeComparison {
+        switch lhs.compare(rhs as Date) {
+        case .orderedAscending:
+            return .lessThan
+        case .orderedSame:
+            return .equal
+        case .orderedDescending:
+            return .greaterThan
+        }
+    }
+}

--- a/CalendrTests/Schedulers/TrackedHistoricalScheduler.swift
+++ b/CalendrTests/Schedulers/TrackedHistoricalScheduler.swift
@@ -1,0 +1,24 @@
+//
+//  TrackedHistoricalScheduler.swift
+//  CalendrTests
+//
+//  Created by Paker on 08/03/2021.
+//
+
+import RxSwift
+
+class TrackedHistoricalScheduler : VirtualTimeScheduler<HistoricalSchedulerTimeConverter> {
+
+    var log: [VirtualTime] = []
+
+    init(initialClock: RxTime = Date(timeIntervalSince1970: 0)) {
+        super.init(initialClock: initialClock, converter: .init())
+    }
+
+    /// Adjusts time of scheduling (and log it ☝🏻) before adding item to schedule queue.
+    public override func adjustScheduledTime(_ time: VirtualTime) -> VirtualTime {
+        let time = super.adjustScheduledTime(time)
+        log.append(time)
+        return time
+    }
+}

--- a/CalendrTests/Schedulers/VirtualTimeScheduler.swift
+++ b/CalendrTests/Schedulers/VirtualTimeScheduler.swift
@@ -1,5 +1,5 @@
 //
-//  HistoricalScheduler.swift
+//  VirtualTimeScheduler.swift
 //  CalendrTests
 //
 //  Created by Paker on 06/02/21.
@@ -7,7 +7,7 @@
 
 import RxSwift
 
-extension HistoricalScheduler {
+extension VirtualTimeScheduler where VirtualTime == RxTime {
 
     func advance(_ interval: RxTimeInterval) {
         advanceTo(clock + interval.timeInterval)
@@ -19,7 +19,7 @@ extension HistoricalScheduler {
 }
 
 extension RxTimeInterval {
-    // Shamelessly copied from ReactiveSwift 😅
+    
     var timeInterval: TimeInterval {
         switch self {
         case let .seconds(s):


### PR DESCRIPTION
1. Refresh event list only `after` event end, not `at` the end
2. Fix wrong today section with multi-day event