### PR TITLE
Fix switching screens with "pinned" calendar

### DIFF
--- a/Calendr.xcodeproj/project.pbxproj
+++ b/Calendr.xcodeproj/project.pbxproj
@@ -1259,7 +1259,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 1.10.2;
+				MARKETING_VERSION = 1.10.3;
 				PRODUCT_BUNDLE_IDENTIFIER = br.paker.Calendr;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Calendr/Config/Calendr-Bridging-Header.h";
@@ -1285,7 +1285,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 1.10.2;
+				MARKETING_VERSION = 1.10.3;
 				PRODUCT_BUNDLE_IDENTIFIER = br.paker.Calendr;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Calendr/Config/Calendr-Bridging-Header.h";

--- a/Calendr/Main/MainViewController.swift
+++ b/Calendr/Main/MainViewController.swift
@@ -370,6 +370,16 @@ class MainViewController: NSViewController, NSPopoverDelegate {
         searchInputText
             .bind(to: searchInput.rx.stringValue)
             .disposed(by: disposeBag)
+
+        // 🔨 Dirty hack to force the window to update its position
+        //    when switching screens with pinned (sticky) calendar
+        screenProvider.screenObservable
+            .bind { [weak self] _ in
+                guard let self, let window = self.view.window else { return }
+                window.setContentSize(.zero)
+                window.setContentSize(self.contentSize)
+            }
+            .disposed(by: disposeBag)
     }
 
     private func setUpSettings() {


### PR DESCRIPTION
Focusing another screen with "pinned" calendar would cause it to disappear forever

Fixes #144 