### PR TITLE
Launch menu bar click actions with mouse click down instead of up

### DIFF
--- a/Calendr/Main/MainViewController.swift
+++ b/Calendr/Main/MainViewController.swift
@@ -852,9 +852,9 @@ private class StatusItemClickHandler {
         guard let event = NSApp.currentEvent else { return }
 
         switch event.type {
-        case .leftMouseUp:
+        case .leftMouseDown:
             self.leftClick.onNext(())
-        case .rightMouseUp:
+        case .rightMouseDown:
             self.rightClick.onNext(())
         default:
             break

--- a/Calendr/Main/MainViewController.swift
+++ b/Calendr/Main/MainViewController.swift
@@ -844,6 +844,11 @@ private extension NSMenu {
     }
 }
 
+/**
+ We trigger `left` click on mouse `down` and `right` click on mouse `up` on purpose.
+ Mouse down feels faster, but NSMenu.popUp blocks the event chain and causes the button to be stuck in a weird state.
+ It's not about the highlight effect, it really gets stuck and we have to click it twice for it to work again.
+ **/
 private class StatusItemClickHandler {
     let leftClick = PublishSubject<Void>()
     let rightClick = PublishSubject<Void>()
@@ -854,7 +859,7 @@ private class StatusItemClickHandler {
         switch event.type {
         case .leftMouseDown:
             self.leftClick.onNext(())
-        case .rightMouseDown:
+        case .rightMouseUp:
             self.rightClick.onNext(())
         default:
             break
@@ -865,7 +870,7 @@ private class StatusItemClickHandler {
 private extension NSStatusBarButton {
 
     func setUpClickHandler(_ handler: StatusItemClickHandler) {
-        sendAction(on: [.leftMouseUp, .rightMouseUp])
+        sendAction(on: [.leftMouseDown, .rightMouseUp])
         target = handler
         action = #selector(StatusItemClickHandler.action)
     }


### PR DESCRIPTION
Replace `.leftMouseUp` / `.rightMouseUp` with `.leftMouseDown` / `.rightMouseDown` for menu bar click actions.