### PR TITLE
Add Traditional Chinese (zh-Hant-TW) language

### DIFF
--- a/Calendr.xcodeproj/project.pbxproj
+++ b/Calendr.xcodeproj/project.pbxproj
@@ -401,6 +401,7 @@
 		34F7E03928427AC00028FF25 /* EventDetailsPreview.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventDetailsPreview.swift; sourceTree = "<group>"; };
 		34F96CED25B523ED0020DEEA /* main.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = main.swift; sourceTree = "<group>"; };
 		34FD09D825AE269600AAAAE2 /* DateProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateProvider.swift; sourceTree = "<group>"; };
+		A122CF0E2CDDFD6100B95699 /* zh-Hant-TW */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-Hant-TW"; path = "zh-Hant-TW.lproj/Localizable.strings"; sourceTree = "<group>"; };
 		C492E3CD29FD64BA007C7DF3 /* zh-Hans */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-Hans"; path = "zh-Hans.lproj/Localizable.strings"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -951,6 +952,7 @@
 				cs,
 				sk,
 				sv,
+				"zh-Hant-TW",
 			);
 			mainGroup = 347D0F8B25952F89002451EC;
 			packageReferences = (
@@ -1294,6 +1296,7 @@
 				27F573032B9F4B3B000DA607 /* cs */,
 				34F2F7342BB711F300666507 /* sk */,
 				34D88DC62C4C3D1A0047D636 /* sv */,
+				A122CF0E2CDDFD6100B95699 /* zh-Hant-TW */,
 			);
 			name = Localizable.strings;
 			sourceTree = "<group>";

--- a/Calendr/Assets/zh-Hant-TW.lproj/Localizable.strings
+++ b/Calendr/Assets/zh-Hant-TW.lproj/Localizable.strings
@@ -1,0 +1,113 @@
+/* 
+  Localizable.strings
+  Calendr
+
+  Created by HeiTang on 08/11/2024.
+*/
+
+"quit" = "退出";
+"search" = "搜尋";
+
+"access_required.calendars" = "行事曆需要 '完全存取' 授權";
+"access_required.reminders" = "提醒事項需要授權";
+"access_required.open_settings" = "開啟設定";
+"access_required.cancel" = "取消";
+
+"auto_update.check_for_updates" = "檢查更新";
+"auto_update.fetching_releases" = "正在獲取版本";
+"auto_update.new_version" = "有新版本可用：%@";
+"auto_update.updated_to" = "已更新至版本 %@";
+"auto_update.downloading" = "正在下載版本 %@";
+"auto_update.install" = "安裝";
+"auto_update.replace.message" = "確認應用程式位置以便我們有權限替換它";
+
+"settings.title" = "偏好設定";
+"settings.tab.general" = "一般";
+"settings.tab.appearance" = "外觀";
+"settings.tab.calendars" = "行事曆";
+"settings.tab.keyboard" = "快捷鍵";
+"settings.tab.about" = "關於";
+
+"settings.menu_bar" = "選單列";
+"settings.menu_bar.auto_launch" = "登入時啟動";
+"settings.menu_bar.show_icon" = "顯示圖示";
+"settings.menu_bar.show_date" = "顯示日期";
+"settings.menu_bar.show_icon_date" = "在圖示中顯示日期";
+"settings.menu_bar.show_background" = "顯示不透明背景";
+"settings.menu_bar.date_format_custom" = "自訂";
+
+"settings.next_event" = "下一個事件";
+"settings.next_event.show_next_event" = "顯示下一個事件";
+"settings.next_event.font_size" = "字型大小";
+"settings.next_event.detect_notch" = "若有 '瀏海' 則縮短";
+
+"settings.calendar" = "行事曆";
+"settings.calendar.show_week_numbers" = "顯示週數";
+"settings.calendar.preserve_selected_date" = "隱藏時保留選定日期";
+"settings.calendar.show_declined_events" = "顯示已拒絕的事件";
+"settings.calendar.show_declined_events_tooltip" = "這僅在本機行事曆應用程式中也啟用時有效。";
+"settings.calendar.date_hover_option" = "按住 ⌥ 以預覽懸停日期";
+"settings.calendar.calendar_app_view_mode" = "行事曆應用程式檢視模式";
+
+"settings.events" = "事件";
+"settings.events.show_map" = "顯示地圖和天氣";
+"settings.events.show_overdue_reminders" = "顯示逾期提醒";
+"settings.events.show_finished_events" = "顯示已完成的事件";
+"settings.events.show_recurrence_indicator" = "顯示重複指示器";
+
+"settings.appearance.transparency" = "透明度";
+"settings.appearance.accessibility" = "輔助功能";
+
+"settings.keyboard.local_shortcuts.title" = "本地快捷鍵";
+"settings.keyboard.local_shortcuts.prev_date" = "前一天";
+"settings.keyboard.local_shortcuts.next_date" = "後一天";
+"settings.keyboard.local_shortcuts.prev_week" = "前一週";
+"settings.keyboard.local_shortcuts.next_week" = "後一週";
+"settings.keyboard.local_shortcuts.prev_month" = "前一個月";
+"settings.keyboard.local_shortcuts.next_month" = "後一個月";
+"settings.keyboard.local_shortcuts.curr_date" = "當前日期";
+"settings.keyboard.local_shortcuts.open_date" = "打開選定日期";
+"settings.keyboard.local_shortcuts.pin_calendar" = "固定行事曆";
+
+"settings.keyboard.global_shortcuts.title" = "全域快捷鍵";
+"settings.keyboard.global_shortcuts.open_calendar" = "打開行事曆";
+"settings.keyboard.global_shortcuts.open_next_event" = "打開下一個事件";
+"settings.keyboard.global_shortcuts.open_next_event_options" = "下一個事件選項";
+"settings.keyboard.global_shortcuts.open_next_reminder" = "打開下一個提醒";
+"settings.keyboard.global_shortcuts.open_next_reminder_options" = "下一個提醒選項";
+
+"formatter.date.all_day" = "全天";
+"formatter.date.today" = "今天";
+"formatter.date.relative.in" = "在 %@ 之後";
+"formatter.date.relative.ago" = "%@ 之前";
+"formatter.date.relative.left" = "剩下 %@";
+
+"reminder.options.button" = "選項";
+"reminder.options.complete" = "完成";
+"reminder.options.remind" = "提醒 %@";
+
+"event_details.participant.organizer" = "組織者";
+"event_details.participant.me" = "我";
+
+"event_status.label" = "我的狀態：";
+
+"event_status.accepted" = "已接受";
+"event_status.maybe" = "可能";
+"event_status.declined" = "已拒絕";
+"event_status.pending" = "待定";
+
+"event_action.open" = "打開";
+"event_action.join" = "加入";
+"event_action.skip" = "跳過";
+"event_action.accept" = "接受";
+"event_action.maybe" = "可能";
+"event_action.decline" = "拒絕";
+
+"tooltips.navigation.prev_month" = "前一個月";
+"tooltips.navigation.today" = "今天";
+"tooltips.navigation.next_month" = "後一個月";
+
+"tooltips.toolbar.stay_open" = "保持打開";
+"tooltips.toolbar.open_calendar" = "打開行事曆";
+"tooltips.toolbar.open_reminders" = "打開提醒";
+"tooltips.toolbar.open_menu" = "打開選單";


### PR DESCRIPTION
### Summary
Added localization support for Traditional Chinese (zh-Hant-TW).

### Changes
- Translated all strings in `Localizable.strings` to Traditional Chinese.
- Ensured the translations use terms commonly used in Taiwan.

### Notes
This PR adds support for Traditional Chinese language, enhancing the user experience for users in Taiwan.