### PR TITLE
Add deep-link support for dates

### DIFF
--- a/Calendr/Config/Info.plist
+++ b/Calendr/Config/Info.plist
@@ -20,6 +20,17 @@
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
 	<string>$(MARKETING_VERSION)</string>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleURLName</key>
+			<string>br.paker.calendr</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>calendr</string>
+			</array>
+		</dict>
+	</array>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>LSApplicationCategoryType</key>

--- a/Calendr/Main/AppDelegate.swift
+++ b/Calendr/Main/AppDelegate.swift
@@ -6,10 +6,13 @@
 //
 
 import Cocoa
+import RxSwift
 
 class AppDelegate: NSObject, NSApplicationDelegate {
 
     private var viewController: NSViewController?
+
+    private let deeplink = BehaviorSubject<URL?>(value: nil)
 
     func applicationDidFinishLaunching(_ notification: Notification) {
 
@@ -36,6 +39,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         let notificationProvider = LocalNotificationProvider()
 
         viewController = MainViewController(
+            deeplink: deeplink.skipNil(),
             autoLauncher: .default,
             workspace: workspace,
             calendarService: CalendarServiceProvider(
@@ -44,10 +48,10 @@ class AppDelegate: NSObject, NSApplicationDelegate {
                 userDefaults: userDefaults,
                 notificationCenter: notificationCenter
             ),
-            geocoder: GeocodeServiceProvider(), 
+            geocoder: GeocodeServiceProvider(),
             weatherService: .make(dateProvider: dateProvider),
             dateProvider: dateProvider,
-            screenProvider: ScreenProvider(notificationCenter: notificationCenter), 
+            screenProvider: ScreenProvider(notificationCenter: notificationCenter),
             notificationProvider: notificationProvider,
             networkProvider: NetworkServiceProvider(),
             userDefaults: userDefaults,
@@ -57,5 +61,10 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
         setUpEditShortcuts()
         setUpResignFocus()
+    }
+
+    func application(_ application: NSApplication, open urls: [URL]) {
+        guard let url = urls.first else { return }
+        deeplink.onNext(url)
     }
 }

--- a/Calendr/Main/MockMainViewController.swift
+++ b/Calendr/Main/MockMainViewController.swift
@@ -34,6 +34,7 @@ class MockMainViewController: MainViewController {
         let fileManager = FileManager.default
 
         super.init(
+            deeplink: .empty(),
             autoLauncher: AutoLauncher(),
             workspace: NSWorkspace.shared,
             calendarService: MockCalendarServiceProvider(dateProvider: dateProvider),


### PR DESCRIPTION
Closes #314 

Example: `open calendr://date/20241225` 🎄