### PR TITLE
Add deep-link natural language support

### DIFF
--- a/Calendr/Main/MainViewController.swift
+++ b/Calendr/Main/MainViewController.swift
@@ -796,15 +796,14 @@ class MainViewController: NSViewController {
             .ignoreElements()
             .asCompletable()
 
-        let formatter = DateFormatter(format: "yyyyMMdd", calendar: dateProvider.calendar)
-
         let date = handleColdStart
             .andThen(deeplink)
-            .compactMap { url -> Date? in
+            .compactMap { [dateProvider] url -> Date? in
                 guard let action = url.host, action == "date" else {
                     return nil
                 }
-                return formatter.date(from: url.lastPathComponent)
+                let result = DateSearchParser.parse(text: url.lastPathComponent, using: dateProvider)
+                return result?.date
             }
             .share(replay: 1)
 


### PR DESCRIPTION
Closes #314 

Examples:
date|encoded
--|--
`december`|`calendr://date/december` (defaults to current date and year)
`feb 10 2025`|`calendr://date/feb%2010%202025`
`2nd of September 2025`|`calendr://date/2nd%20of%20September%202025`

It has limited support to relative dates like: `today`, `yesterday`, `tomorrow`
but will not work with `next week`, `last month`, etc.

That's how `NSDataDetector` works ¯\\_\(ツ\)\_/¯