### PR TITLE
Scroll to next event + today summary

### DIFF
--- a/Calendr.xcodeproj/project.pbxproj
+++ b/Calendr.xcodeproj/project.pbxproj
@@ -1547,7 +1547,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 1.15.9;
+				MARKETING_VERSION = 1.16.0;
 				PRODUCT_BUNDLE_IDENTIFIER = br.paker.Calendr;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Calendr/Config/Calendr-Bridging-Header.h";
@@ -1575,7 +1575,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 1.15.9;
+				MARKETING_VERSION = 1.16.0;
 				PRODUCT_BUNDLE_IDENTIFIER = br.paker.Calendr;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Calendr/Config/Calendr-Bridging-Header.h";

--- a/Calendr/Assets/Strings.generated.swift
+++ b/Calendr/Assets/Strings.generated.swift
@@ -57,42 +57,44 @@ internal enum Strings {
       internal static let others = Strings.tr("Localizable", "calendars.source.others", fallback: "Others")
     }
   }
-  internal enum EventAction {
-    /// Accept
-    internal static let accept = Strings.tr("Localizable", "event_action.accept", fallback: "Accept")
-    /// Decline
-    internal static let decline = Strings.tr("Localizable", "event_action.decline", fallback: "Decline")
-    /// Join
-    internal static let join = Strings.tr("Localizable", "event_action.join", fallback: "Join")
-    /// Maybe
-    internal static let maybe = Strings.tr("Localizable", "event_action.maybe", fallback: "Maybe")
-    /// Open
-    internal static let `open` = Strings.tr("Localizable", "event_action.open", fallback: "Open")
-    /// Skip
-    internal static let skip = Strings.tr("Localizable", "event_action.skip", fallback: "Skip")
-  }
-  internal enum EventDetails {
-    internal enum Participant {
-      /// me
-      internal static let me = Strings.tr("Localizable", "event_details.participant.me", fallback: "me")
-      /// organizer
-      internal static let organizer = Strings.tr("Localizable", "event_details.participant.organizer", fallback: "organizer")
+  internal enum Event {
+    /// All day
+    internal static let allDay = Strings.tr("Localizable", "event.all_day", fallback: "All day")
+    internal enum Action {
+      /// Accept
+      internal static let accept = Strings.tr("Localizable", "event.action.accept", fallback: "Accept")
+      /// Decline
+      internal static let decline = Strings.tr("Localizable", "event.action.decline", fallback: "Decline")
+      /// Join
+      internal static let join = Strings.tr("Localizable", "event.action.join", fallback: "Join")
+      /// Maybe
+      internal static let maybe = Strings.tr("Localizable", "event.action.maybe", fallback: "Maybe")
+      /// Open
+      internal static let `open` = Strings.tr("Localizable", "event.action.open", fallback: "Open")
+      /// Skip
+      internal static let skip = Strings.tr("Localizable", "event.action.skip", fallback: "Skip")
     }
-  }
-  internal enum EventStatus {
-    /// Accepted
-    internal static let accepted = Strings.tr("Localizable", "event_status.accepted", fallback: "Accepted")
-    /// Declined
-    internal static let declined = Strings.tr("Localizable", "event_status.declined", fallback: "Declined")
-    /// Maybe
-    internal static let maybe = Strings.tr("Localizable", "event_status.maybe", fallback: "Maybe")
-    /// Pending
-    internal static let pending = Strings.tr("Localizable", "event_status.pending", fallback: "Pending")
+    internal enum Details {
+      internal enum Participant {
+        /// me
+        internal static let me = Strings.tr("Localizable", "event.details.participant.me", fallback: "me")
+        /// organizer
+        internal static let organizer = Strings.tr("Localizable", "event.details.participant.organizer", fallback: "organizer")
+      }
+    }
+    internal enum Status {
+      /// Accepted
+      internal static let accepted = Strings.tr("Localizable", "event.status.accepted", fallback: "Accepted")
+      /// Declined
+      internal static let declined = Strings.tr("Localizable", "event.status.declined", fallback: "Declined")
+      /// Maybe
+      internal static let maybe = Strings.tr("Localizable", "event.status.maybe", fallback: "Maybe")
+      /// Pending
+      internal static let pending = Strings.tr("Localizable", "event.status.pending", fallback: "Pending")
+    }
   }
   internal enum Formatter {
     internal enum Date {
-      /// All day
-      internal static let allDay = Strings.tr("Localizable", "formatter.date.all_day", fallback: "All day")
       /// Today
       internal static let today = Strings.tr("Localizable", "formatter.date.today", fallback: "Today")
       internal enum Relative {
@@ -121,6 +123,10 @@ internal enum Strings {
       internal static func remind(_ p1: Any) -> String {
         return Strings.tr("Localizable", "reminder.options.remind", String(describing: p1), fallback: "Remind %@")
       }
+    }
+    internal enum Status {
+      /// Overdue
+      internal static let overdue = Strings.tr("Localizable", "reminder.status.overdue", fallback: "Overdue")
     }
   }
   internal enum Settings {

--- a/Calendr/Assets/cs.lproj/Localizable.strings
+++ b/Calendr/Assets/cs.lproj/Localizable.strings
@@ -78,30 +78,33 @@
 "settings.keyboard.global_shortcuts.open_next_reminder" = "Otevřít další připomínku";
 "settings.keyboard.global_shortcuts.open_next_reminder_options" = "Možnosti další připomínky";
 
-"formatter.date.all_day" = "Celý den";
 "formatter.date.today" = "Dnes";
 "formatter.date.relative.in" = "za %@";
 "formatter.date.relative.ago" = "před %@";
 "formatter.date.relative.left" = "zbývá %@";
 
+//"reminder.status.overdue" = "Overdue";
+
 "reminder.options.button" = "Možnosti";
 "reminder.options.complete" = "Dokončit";
 "reminder.options.remind" = "Připomenout %@";
 
-"event_details.participant.organizer" = "pořadatel";
-"event_details.participant.me" = "já";
+"event.details.participant.organizer" = "pořadatel";
+"event.details.participant.me" = "já";
 
-"event_status.accepted" = "Přijato";
-"event_status.maybe" = "Možná";
-"event_status.declined" = "Odmítnuto";
-"event_status.pending" = "Čeká";
+"event.all_day" = "Celý den";
 
-"event_action.open" = "Otevřít";
-"event_action.join" = "Připojit se";
-"event_action.skip" = "Přeskočit";
-"event_action.accept" = "Přijmout";
-"event_action.maybe" = "Možná";
-"event_action.decline" = "Odmítnout";
+"event.status.accepted" = "Přijato";
+"event.status.maybe" = "Možná";
+"event.status.declined" = "Odmítnuto";
+"event.status.pending" = "Čeká";
+
+"event.action.open" = "Otevřít";
+"event.action.join" = "Připojit se";
+"event.action.skip" = "Přeskočit";
+"event.action.accept" = "Přijmout";
+"event.action.maybe" = "Možná";
+"event.action.decline" = "Odmítnout";
 
 "tooltips.navigation.prev_month" = "Předchozí měsíc";
 "tooltips.navigation.today" = "Dnes";

--- a/Calendr/Assets/de.lproj/Localizable.strings
+++ b/Calendr/Assets/de.lproj/Localizable.strings
@@ -78,30 +78,33 @@
 "settings.keyboard.global_shortcuts.open_next_reminder" = "Nächste Erinnerung öffnen";
 "settings.keyboard.global_shortcuts.open_next_reminder_options" = "Optionen für nächste Erinnerung";
 
-"formatter.date.all_day" = "Ganztägige Ereignisse";
 "formatter.date.today" = "Heute";
 "formatter.date.relative.in" = "in %@";
 "formatter.date.relative.ago" = "vor %@";
 "formatter.date.relative.left" = "%@ verbleibend";
 
+//"reminder.status.overdue" = "Overdue";
+
 "reminder.options.button" = "Optionen";
 "reminder.options.complete" = "Erledigt";
 "reminder.options.remind" = "Erinnerung %@";
 
-"event_details.participant.organizer" = "Veranstaltende Person";
-"event_details.participant.me" = "Ich";
+"event.details.participant.organizer" = "Veranstaltende Person";
+"event.details.participant.me" = "Ich";
 
-"event_status.accepted" = "Akzeptiert";
-"event_status.maybe" = "Vielleicht";
-"event_status.declined" = "Abgelehnt";
-"event_status.pending" = "Ausstehend";
+"event.all_day" = "Ganztägige Ereignisse";
 
-"event_action.open" = "Öffnen";
-"event_action.join" = "Beitreten";
-"event_action.skip" = "Überspringen";
-"event_action.accept" = "Akzeptieren";
-"event_action.maybe" = "Vielleicht";
-"event_action.decline" = "Ablehnen";
+"event.status.accepted" = "Akzeptiert";
+"event.status.maybe" = "Vielleicht";
+"event.status.declined" = "Abgelehnt";
+"event.status.pending" = "Ausstehend";
+
+"event.action.open" = "Öffnen";
+"event.action.join" = "Beitreten";
+"event.action.skip" = "Überspringen";
+"event.action.accept" = "Akzeptieren";
+"event.action.maybe" = "Vielleicht";
+"event.action.decline" = "Ablehnen";
 
 "tooltips.navigation.prev_month" = "Vorheriger Monat";
 "tooltips.navigation.today" = "Heute";

--- a/Calendr/Assets/el.lproj/Localizable.strings
+++ b/Calendr/Assets/el.lproj/Localizable.strings
@@ -78,30 +78,33 @@
 "settings.keyboard.global_shortcuts.open_next_reminder" = "Άνοιγμα επόμενης υπενθύμισης";
 "settings.keyboard.global_shortcuts.open_next_reminder_options" = "Επιλογές επόμενης υπενθύμισης";
 
-"formatter.date.all_day" = "Όλη την ημέρα";
 "formatter.date.today" = "Σήμερα";
 "formatter.date.relative.in" = "σε %@";
 "formatter.date.relative.ago" = "%@ πριν";
 "formatter.date.relative.left" = "%@ μείνανε";
 
+//"reminder.status.overdue" = "Overdue";
+
 "reminder.options.button" = "Επιλογές";
 "reminder.options.complete" = "Ολοκληρώθηκε";
 "reminder.options.remind" = "Υπενθύμιση %@";
 
-"event_details.participant.organizer" = "διοργανωτής";
-"event_details.participant.me" = "εγω";
+"event.details.participant.organizer" = "διοργανωτής";
+"event.details.participant.me" = "εγω";
 
-"event_status.accepted" = "Αποδεκτή";
-"event_status.maybe" = "Ίσως";
-"event_status.declined" = "Απορρίφθηκε";
-"event_status.pending" = "Εκκρεμεί";
+"event.all_day" = "Όλη την ημέρα";
 
-"event_action.open" = "Άνοιγμα";
-"event_action.join" = "Συμμετοχή";
-"event_action.skip" = "Παράλειψη";
-"event_action.accept" = "Αποδοχή";
-"event_action.maybe" = "Ίσως";
-"event_action.decline" = "Απορρίπτεται";
+"event.status.accepted" = "Αποδεκτή";
+"event.status.maybe" = "Ίσως";
+"event.status.declined" = "Απορρίφθηκε";
+"event.status.pending" = "Εκκρεμεί";
+
+"event.action.open" = "Άνοιγμα";
+"event.action.join" = "Συμμετοχή";
+"event.action.skip" = "Παράλειψη";
+"event.action.accept" = "Αποδοχή";
+"event.action.maybe" = "Ίσως";
+"event.action.decline" = "Απορρίπτεται";
 
 "tooltips.navigation.prev_month" = "Προηγούμενος μήνας";
 "tooltips.navigation.today" = "Σήμερα";

--- a/Calendr/Assets/en.lproj/Localizable.strings
+++ b/Calendr/Assets/en.lproj/Localizable.strings
@@ -78,30 +78,33 @@
 "settings.keyboard.global_shortcuts.open_next_reminder" = "Open next reminder";
 "settings.keyboard.global_shortcuts.open_next_reminder_options" = "Next reminder options";
 
-"formatter.date.all_day" = "All day";
 "formatter.date.today" = "Today";
 "formatter.date.relative.in" = "in %@";
 "formatter.date.relative.ago" = "%@ ago";
 "formatter.date.relative.left" = "%@ left";
 
+"reminder.status.overdue" = "Overdue";
+
 "reminder.options.button" = "Options";
 "reminder.options.complete" = "Complete";
 "reminder.options.remind" = "Remind %@";
 
-"event_details.participant.organizer" = "organizer";
-"event_details.participant.me" = "me";
+"event.details.participant.organizer" = "organizer";
+"event.details.participant.me" = "me";
 
-"event_status.accepted" = "Accepted";
-"event_status.maybe" = "Maybe";
-"event_status.declined" = "Declined";
-"event_status.pending" = "Pending";
+"event.all_day" = "All day";
 
-"event_action.open" = "Open";
-"event_action.join" = "Join";
-"event_action.skip" = "Skip";
-"event_action.accept" = "Accept";
-"event_action.maybe" = "Maybe";
-"event_action.decline" = "Decline";
+"event.status.accepted" = "Accepted";
+"event.status.maybe" = "Maybe";
+"event.status.declined" = "Declined";
+"event.status.pending" = "Pending";
+
+"event.action.open" = "Open";
+"event.action.join" = "Join";
+"event.action.skip" = "Skip";
+"event.action.accept" = "Accept";
+"event.action.maybe" = "Maybe";
+"event.action.decline" = "Decline";
 
 "tooltips.navigation.prev_month" = "Previous month";
 "tooltips.navigation.today" = "Today";

--- a/Calendr/Assets/es.lproj/Localizable.strings
+++ b/Calendr/Assets/es.lproj/Localizable.strings
@@ -78,30 +78,33 @@
 "settings.keyboard.global_shortcuts.open_next_reminder" = "Abrir próximo recordatorio";
 "settings.keyboard.global_shortcuts.open_next_reminder_options" = "Opciones del próximo recordatorio";
 
-"formatter.date.all_day" = "Todo el día";
 "formatter.date.today" = "Hoy";
 "formatter.date.relative.in" = "en %@";
 "formatter.date.relative.ago" = "hace %@";
 "formatter.date.relative.left" = "%@ rest.";
 
+//"reminder.status.overdue" = "Overdue";
+
 "reminder.options.button" = "Opciones";
 "reminder.options.complete" = "Completado";
 "reminder.options.remind" = "Recordar %@";
 
-"event_details.participant.organizer" = "organizador";
-"event_details.participant.me" = "me";
+"event.details.participant.organizer" = "organizador";
+"event.details.participant.me" = "me";
 
-"event_status.accepted" = "Aceptado";
-"event_status.maybe" = "Quizá";
-"event_status.declined" = "Rechazado";
-"event_status.pending" = "Pendiente";
+"event.all_day" = "Todo el día";
 
-"event_action.open" = "Abrir";
-"event_action.join" = "Unirse";
-"event_action.skip" = "Saltar";
-"event_action.accept" = "Aceptar";
-"event_action.maybe" = "Quizá";
-"event_action.decline" = "Rechazar";
+"event.status.accepted" = "Aceptado";
+"event.status.maybe" = "Quizá";
+"event.status.declined" = "Rechazado";
+"event.status.pending" = "Pendiente";
+
+"event.action.open" = "Abrir";
+"event.action.join" = "Unirse";
+"event.action.skip" = "Saltar";
+"event.action.accept" = "Aceptar";
+"event.action.maybe" = "Quizá";
+"event.action.decline" = "Rechazar";
 
 "tooltips.navigation.prev_month" = "Mes anterior";
 "tooltips.navigation.today" = "Hoy";

--- a/Calendr/Assets/fr.lproj/Localizable.strings
+++ b/Calendr/Assets/fr.lproj/Localizable.strings
@@ -78,30 +78,33 @@
 "settings.keyboard.global_shortcuts.open_next_reminder" = "Ouvrir le prochain rappel";
 "settings.keyboard.global_shortcuts.open_next_reminder_options" = "Options du prochain rappel";
 
-"formatter.date.all_day" = "Toute la journée";
 "formatter.date.today" = "Aujourd'hui";
 "formatter.date.relative.in" = "dans %@";
 "formatter.date.relative.ago" = "il y a %@";
 "formatter.date.relative.left" = "%@ rest.";
 
+//"reminder.status.overdue" = "Overdue";
+
 "reminder.options.button" = "Options";
 "reminder.options.complete" = "Terminé";
 "reminder.options.remind" = "Rappel %@";
 
-"event_details.participant.organizer" = "organisateur";
-"event_details.participant.me" = "moi";
+"event.details.participant.organizer" = "organisateur";
+"event.details.participant.me" = "moi";
 
-"event_status.accepted" = "Accepté";
-"event_status.maybe" = "Peut-être";
-"event_status.declined" = "Refusé";
-"event_status.pending" = "En attente";
+"event.all_day" = "Toute la journée";
 
-"event_action.open" = "Ouvrir";
-"event_action.join" = "Rejoindre";
-"event_action.skip" = "Sauter";
-"event_action.accept" = "Accepter";
-"event_action.maybe" = "Peut-être";
-"event_action.decline" = "Refuser";
+"event.status.accepted" = "Accepté";
+"event.status.maybe" = "Peut-être";
+"event.status.declined" = "Refusé";
+"event.status.pending" = "En attente";
+
+"event.action.open" = "Ouvrir";
+"event.action.join" = "Rejoindre";
+"event.action.skip" = "Sauter";
+"event.action.accept" = "Accepter";
+"event.action.maybe" = "Peut-être";
+"event.action.decline" = "Refuser";
 
 "tooltips.navigation.prev_month" = "Mois précédent";
 "tooltips.navigation.today" = "Aujourd'hui";

--- a/Calendr/Assets/it.lproj/Localizable.strings
+++ b/Calendr/Assets/it.lproj/Localizable.strings
@@ -79,30 +79,33 @@
 "settings.keyboard.global_shortcuts.open_next_reminder" = "Aprire il prossimo promemoria";
 "settings.keyboard.global_shortcuts.open_next_reminder_options" = "Opzioni del prossimo promemoria";
 
-"formatter.date.all_day" = "Tutto il giorno";
 "formatter.date.today" = "Oggi";
 "formatter.date.relative.in" = "in %@";
 "formatter.date.relative.ago" = "%@ fa";
 "formatter.date.relative.left" = "%@ rimasto";
 
+//"reminder.status.overdue" = "Overdue";
+
 "reminder.options.button" = "Opzioni";
 "reminder.options.complete" = "Completato";
 "reminder.options.remind" = "Ricorda %@";
 
-"event_details.participant.organizer" = "Organizzatore";
-"event_details.participant.me" = "io";
+"event.details.participant.organizer" = "Organizzatore";
+"event.details.participant.me" = "io";
 
-"event_status.accepted" = "Accettato";
-"event_status.maybe" = "Forse";
-"event_status.declined" = "Rifiutato";
-"event_status.pending" = "In attesa";
+"event.all_day" = "Tutto il giorno";
 
-"event_action.open" = "Aprire";
-"event_action.join" = "Partecipare";
-"event_action.skip" = "Saltare";
-"event_action.accept" = "Accetta";
-"event_action.maybe" = "Forse";
-"event_action.decline" = "Rifiuta";
+"event.status.accepted" = "Accettato";
+"event.status.maybe" = "Forse";
+"event.status.declined" = "Rifiutato";
+"event.status.pending" = "In attesa";
+
+"event.action.open" = "Aprire";
+"event.action.join" = "Partecipare";
+"event.action.skip" = "Saltare";
+"event.action.accept" = "Accetta";
+"event.action.maybe" = "Forse";
+"event.action.decline" = "Rifiuta";
 
 "tooltips.navigation.prev_month" = "Mese precedente";
 "tooltips.navigation.today" = "Oggi";

--- a/Calendr/Assets/ja.lproj/Localizable.strings
+++ b/Calendr/Assets/ja.lproj/Localizable.strings
@@ -78,30 +78,33 @@
 "settings.keyboard.global_shortcuts.open_next_reminder" = "次のリマインダーを展開";
 "settings.keyboard.global_shortcuts.open_next_reminder_options" = "次のリマインダーのオプションを表示";
 
-"formatter.date.all_day" = "全日";
 "formatter.date.today" = "今日";
 "formatter.date.relative.in" = "%@後";
 "formatter.date.relative.ago" = "%@前";
 "formatter.date.relative.left" = "残り%@";
 
+//"reminder.status.overdue" = "Overdue";
+
 "reminder.options.button" = "オプション";
 "reminder.options.complete" = "完了";
 "reminder.options.remind" = "%@ にリマインド";
 
-"event_details.participant.organizer" = "主催者";
-"event_details.participant.me" = "自分";
+"event.details.participant.organizer" = "主催者";
+"event.details.participant.me" = "自分";
 
-"event_status.accepted" = "出席";
-"event_status.maybe" = "仮承諾";
-"event_status.declined" = "欠席";
-"event_status.pending" = "未回答";
+"event.all_day" = "全日";
 
-"event_action.open" = "開く";
-"event_action.join" = "参加する";
-"event_action.skip" = "スキップ";
-"event_action.accept" = "出席";
-"event_action.maybe" = "仮承諾";
-"event_action.decline" = "欠席";
+"event.status.accepted" = "出席";
+"event.status.maybe" = "仮承諾";
+"event.status.declined" = "欠席";
+"event.status.pending" = "未回答";
+
+"event.action.open" = "開く";
+"event.action.join" = "参加する";
+"event.action.skip" = "スキップ";
+"event.action.accept" = "出席";
+"event.action.maybe" = "仮承諾";
+"event.action.decline" = "欠席";
 
 "tooltips.navigation.prev_month" = "先月";
 "tooltips.navigation.today" = "今日";

--- a/Calendr/Assets/ko.lproj/Localizable.strings
+++ b/Calendr/Assets/ko.lproj/Localizable.strings
@@ -78,30 +78,33 @@
 "settings.keyboard.global_shortcuts.open_next_reminder" = "다음 미리 알림 열기";
 "settings.keyboard.global_shortcuts.open_next_reminder_options" = "다음 미리 알림 옵션";
 
-"formatter.date.all_day" = "하루 종일";
 "formatter.date.today" = "오늘";
 "formatter.date.relative.in" = "%@ 후";
 "formatter.date.relative.ago" = "%@ 전";
 "formatter.date.relative.left" = "%@ 남음";
 
+//"reminder.status.overdue" = "Overdue";
+
 "reminder.options.button" = "옵션";
 "reminder.options.complete" = "완료";
 "reminder.options.remind" = "%@ 후 알림";
 
-"event_details.participant.organizer" = "주최자";
-"event_details.participant.me" = "나";
+"event.details.participant.organizer" = "주최자";
+"event.details.participant.me" = "나";
 
-"event_status.accepted" = "수락됨";
-"event_status.maybe" = "미정";
-"event_status.declined" = "거절됨";
-"event_status.pending" = "대기 중";
+"event.all_day" = "하루 종일";
 
-"event_action.open" = "열기";
-"event_action.join" = "참여";
-"event_action.skip" = "건너뛰기";
-"event_action.accept" = "수락";
-"event_action.maybe" = "미정";
-"event_action.decline" = "거절";
+"event.status.accepted" = "수락됨";
+"event.status.maybe" = "미정";
+"event.status.declined" = "거절됨";
+"event.status.pending" = "대기 중";
+
+"event.action.open" = "열기";
+"event.action.join" = "참여";
+"event.action.skip" = "건너뛰기";
+"event.action.accept" = "수락";
+"event.action.maybe" = "미정";
+"event.action.decline" = "거절";
 
 "tooltips.navigation.prev_month" = "이전 달";
 "tooltips.navigation.today" = "오늘";

--- a/Calendr/Assets/pt.lproj/Localizable.strings
+++ b/Calendr/Assets/pt.lproj/Localizable.strings
@@ -78,30 +78,33 @@
 "settings.keyboard.global_shortcuts.open_next_reminder" = "Abrir próximo lembrete";
 "settings.keyboard.global_shortcuts.open_next_reminder_options" = "Opções do próximo lembrete";
 
-"formatter.date.all_day" = "Dia inteiro";
 "formatter.date.today" = "Hoje";
 "formatter.date.relative.in" = "em %@";
 "formatter.date.relative.ago" = "%@ atrás";
 "formatter.date.relative.left" = "%@ rest.";
 
+//"reminder.status.overdue" = "Overdue";
+
 "reminder.options.button" = "Opções";
 "reminder.options.complete" = "Concluído";
 "reminder.options.remind" = "Lembrar %@";
 
-"event_details.participant.organizer" = "organizador";
-"event_details.participant.me" = "eu";
+"event.details.participant.organizer" = "organizador";
+"event.details.participant.me" = "eu";
 
-"event_status.accepted" = "Aceito";
-"event_status.maybe" = "Talvez";
-"event_status.declined" = "Recusado";
-"event_status.pending" = "Pendente";
+"event.all_day" = "Dia inteiro";
 
-"event_action.open" = "Abrir";
-"event_action.join" = "Entrar";
-"event_action.skip" = "Pular";
-"event_action.accept" = "Aceitar";
-"event_action.maybe" = "Talvez";
-"event_action.decline" = "Recusar";
+"event.status.accepted" = "Aceito";
+"event.status.maybe" = "Talvez";
+"event.status.declined" = "Recusado";
+"event.status.pending" = "Pendente";
+
+"event.action.open" = "Abrir";
+"event.action.join" = "Entrar";
+"event.action.skip" = "Pular";
+"event.action.accept" = "Aceitar";
+"event.action.maybe" = "Talvez";
+"event.action.decline" = "Recusar";
 
 "tooltips.navigation.prev_month" = "Mês anterior";
 "tooltips.navigation.today" = "Hoje";

--- a/Calendr/Assets/ru.lproj/Localizable.strings
+++ b/Calendr/Assets/ru.lproj/Localizable.strings
@@ -79,30 +79,33 @@
 "settings.keyboard.global_shortcuts.open_next_reminder" = "Открыть следующее напоминание";
 "settings.keyboard.global_shortcuts.open_next_reminder_options" = "Открыть настройки следующего напоминания";
 
-"formatter.date.all_day" = "Весь день";
 "formatter.date.today" = "Сегодня";
 "formatter.date.relative.in" = "в %@";
 "formatter.date.relative.ago" = "%@ назад";
 "formatter.date.relative.left" = "%@ осталось";
 
+//"reminder.status.overdue" = "Overdue";
+
 "reminder.options.button" = "Опции";
 "reminder.options.complete" = "Полный";
 "reminder.options.remind" = "Напомнить %@";
 
-"event_details.participant.organizer" = "организатор";
-"event_details.participant.me" = "я";
+"event.details.participant.organizer" = "организатор";
+"event.details.participant.me" = "я";
 
-"event_status.accepted" = "Принято";
-"event_status.maybe" = "Возможно";
-"event_status.declined" = "Отклонено";
-"event_status.pending" = "В ожидании";
+"event.all_day" = "Весь день";
 
-"event_action.open" = "Открыть";
-"event_action.join" = "Присоединиться";
-"event_action.skip" = "Пропустить";
-"event_action.accept" = "Принять";
-"event_action.maybe" = "Возможно";
-"event_action.decline" = "Отклонить";
+"event.status.accepted" = "Принято";
+"event.status.maybe" = "Возможно";
+"event.status.declined" = "Отклонено";
+"event.status.pending" = "В ожидании";
+
+"event.action.open" = "Открыть";
+"event.action.join" = "Присоединиться";
+"event.action.skip" = "Пропустить";
+"event.action.accept" = "Принять";
+"event.action.maybe" = "Возможно";
+"event.action.decline" = "Отклонить";
 
 "tooltips.navigation.prev_month" = "Предыдущий месяц";
 "tooltips.navigation.today" = "Сегодня";

--- a/Calendr/Assets/sk.lproj/Localizable.strings
+++ b/Calendr/Assets/sk.lproj/Localizable.strings
@@ -78,30 +78,33 @@
 "settings.keyboard.global_shortcuts.open_next_reminder" = "Otvoriť ďalšiu pripomienku";
 "settings.keyboard.global_shortcuts.open_next_reminder_options" = "Možnosti ďalšej pripomienky";
 
-"formatter.date.all_day" = "Celý deň";
 "formatter.date.today" = "Dnes";
 "formatter.date.relative.in" = "za %@";
 "formatter.date.relative.ago" = "pred %@";
 "formatter.date.relative.left" = "zostáva %@";
 
+//"reminder.status.overdue" = "Overdue";
+
 "reminder.options.button" = "Možnosti";
 "reminder.options.complete" = "Dokončiť";
 "reminder.options.remind" = "Pripomenúť %@";
 
-"event_details.participant.organizer" = "organizátor";
-"event_details.participant.me" = "ja";
+"event.details.participant.organizer" = "organizátor";
+"event.details.participant.me" = "ja";
 
-"event_status.accepted" = "Prijaté";
-"event_status.maybe" = "Možno";
-"event_status.declined" = "Odmietnuté";
-"event_status.pending" = "Čakajúce";
+"event.all_day" = "Celý deň";
 
-"event_action.open" = "Otvoriť";
-"event_action.join" = "Pripojiť sa";
-"event_action.skip" = "Preskočiť";
-"event_action.accept" = "Prijať";
-"event_action.maybe" = "Možno";
-"event_action.decline" = "Odmietnuť";
+"event.status.accepted" = "Prijaté";
+"event.status.maybe" = "Možno";
+"event.status.declined" = "Odmietnuté";
+"event.status.pending" = "Čakajúce";
+
+"event.action.open" = "Otvoriť";
+"event.action.join" = "Pripojiť sa";
+"event.action.skip" = "Preskočiť";
+"event.action.accept" = "Prijať";
+"event.action.maybe" = "Možno";
+"event.action.decline" = "Odmietnuť";
 
 "tooltips.navigation.prev_month" = "Predchádzajúci mesiac";
 "tooltips.navigation.today" = "Dnes";

--- a/Calendr/Assets/sq.lproj/Localizable.strings
+++ b/Calendr/Assets/sq.lproj/Localizable.strings
@@ -78,30 +78,33 @@
 "settings.keyboard.global_shortcuts.open_next_reminder" = "Hap kujtesën tjetër";
 "settings.keyboard.global_shortcuts.open_next_reminder_options" = "Opsionet e ardhshme përkujtues";
 
-"formatter.date.all_day" = "Gjithë ditën";
 "formatter.date.today" = "Sot";
 "formatter.date.relative.in" = "në %@";
 "formatter.date.relative.ago" = "%@ më parë";
 "formatter.date.relative.left" = "%@ mbeten";
 
+//"reminder.status.overdue" = "Overdue";
+
 "reminder.options.button" = "Opsionet";
 "reminder.options.complete" = "E Plotësuar";
 "reminder.options.remind" = "Kujto %@";
 
-"event_details.participant.organizer" = "organizator";
-"event_details.participant.me" = "unë";
+"event.details.participant.organizer" = "organizator";
+"event.details.participant.me" = "unë";
 
-"event_status.accepted" = "Pranuar";
-"event_status.maybe" = "Ndoshta";
-"event_status.declined" = "Refuzuar";
-"event_status.pending" = "Në Pritje";
+"event.all_day" = "Gjithë ditën";
 
-"event_action.open" = "Hapur";
-"event_action.join" = "Bashkohu";
-"event_action.skip" = "Kapërce";
-"event_action.accept" = "Pranoje";
-"event_action.maybe" = "Ndoshta";
-"event_action.decline" = "Rënia";
+"event.status.accepted" = "Pranuar";
+"event.status.maybe" = "Ndoshta";
+"event.status.declined" = "Refuzuar";
+"event.status.pending" = "Në Pritje";
+
+"event.action.open" = "Hapur";
+"event.action.join" = "Bashkohu";
+"event.action.skip" = "Kapërce";
+"event.action.accept" = "Pranoje";
+"event.action.maybe" = "Ndoshta";
+"event.action.decline" = "Rënia";
 
 "tooltips.navigation.prev_month" = "Muajin e kaluar";
 "tooltips.navigation.today" = "Sot";

--- a/Calendr/Assets/sv.lproj/Localizable.strings
+++ b/Calendr/Assets/sv.lproj/Localizable.strings
@@ -78,30 +78,33 @@
 "settings.keyboard.global_shortcuts.open_next_reminder" = "Öppna nästa påminnelse";
 "settings.keyboard.global_shortcuts.open_next_reminder_options" = "Nästa påminnelsealternativ";
 
-"formatter.date.all_day" = "Heldag";
 "formatter.date.today" = "Idag";
 "formatter.date.relative.in" = "om %@";
 "formatter.date.relative.ago" = "%@ sedan";
 "formatter.date.relative.left" = "%@ kvar";
 
+//"reminder.status.overdue" = "Overdue";
+
 "reminder.options.button" = "Alternativ";
 "reminder.options.complete" = "Klar";
 "reminder.options.remind" = "Påminn %@";
 
-"event_details.participant.organizer" = "arrangören";
-"event_details.participant.me" = "jag";
+"event.details.participant.organizer" = "arrangören";
+"event.details.participant.me" = "jag";
 
-"event_status.accepted" = "Godkänd";
-"event_status.maybe" = "Kanske";
-"event_status.declined" = "Avböjd";
-"event_status.pending" = "Väntande";
+"event.all_day" = "Heldag";
 
-"event_action.open" = "Öppna";
-"event_action.join" = "Gå med";
-"event_action.skip" = "Skippa";
-"event_action.accept" = "Tacka ja";
-"event_action.maybe" = "Kanske";
-"event_action.decline" = "Avböj";
+"event.status.accepted" = "Godkänd";
+"event.status.maybe" = "Kanske";
+"event.status.declined" = "Avböjd";
+"event.status.pending" = "Väntande";
+
+"event.action.open" = "Öppna";
+"event.action.join" = "Gå med";
+"event.action.skip" = "Skippa";
+"event.action.accept" = "Tacka ja";
+"event.action.maybe" = "Kanske";
+"event.action.decline" = "Avböj";
 
 "tooltips.navigation.prev_month" = "Föregående månad";
 "tooltips.navigation.today" = "Idag";

--- a/Calendr/Assets/tr.lproj/Localizable.strings
+++ b/Calendr/Assets/tr.lproj/Localizable.strings
@@ -78,30 +78,33 @@
 "settings.keyboard.global_shortcuts.open_next_reminder" = "Sonraki hatırlatıcıyı aç";
 "settings.keyboard.global_shortcuts.open_next_reminder_options" = "Sonraki hatırlatıcı seçenekleri";
 
-"formatter.date.all_day" = "Tüm gün";
 "formatter.date.today" = "Bugün";
 "formatter.date.relative.in" = "%@ içinde";
 "formatter.date.relative.ago" = "%@ önce";
 "formatter.date.relative.left" = "%@ kaldı";
 
+//"reminder.status.overdue" = "Overdue";
+
 "reminder.options.button" = "Seçenekler";
 "reminder.options.complete" = "Tamamlandı";
 "reminder.options.remind" = "%@ hatırlat";
 
-"event_details.participant.organizer" = "organizatör";
-"event_details.participant.me" = "ben";
+"event.details.participant.organizer" = "organizatör";
+"event.details.participant.me" = "ben";
 
-"event_status.accepted" = "Kabul edildi";
-"event_status.maybe" = "Belki";
-"event_status.declined" = "Reddedildi";
-"event_status.pending" = "Beklemede";
+"event.all_day" = "Tüm gün";
 
-"event_action.open" = "Aç";
-"event_action.join" = "Katıl";
-"event_action.skip" = "Atla";
-"event_action.accept" = "Kabul et";
-"event_action.maybe" = "Belki";
-"event_action.decline" = "Reddet";
+"event.status.accepted" = "Kabul edildi";
+"event.status.maybe" = "Belki";
+"event.status.declined" = "Reddedildi";
+"event.status.pending" = "Beklemede";
+
+"event.action.open" = "Aç";
+"event.action.join" = "Katıl";
+"event.action.skip" = "Atla";
+"event.action.accept" = "Kabul et";
+"event.action.maybe" = "Belki";
+"event.action.decline" = "Reddet";
 
 "tooltips.navigation.prev_month" = "Önceki ay";
 "tooltips.navigation.today" = "Bugün";

--- a/Calendr/Assets/uk.lproj/Localizable.strings
+++ b/Calendr/Assets/uk.lproj/Localizable.strings
@@ -78,30 +78,33 @@
 "settings.keyboard.global_shortcuts.open_next_reminder" = "Відкрити наступне нагадування";
 "settings.keyboard.global_shortcuts.open_next_reminder_options" = "Відкрити налаштування наступного нагадування";
 
-"formatter.date.all_day" = "Весь день";
 "formatter.date.today" = "Сьогодні";
 "formatter.date.relative.in" = "через %@";
 "formatter.date.relative.ago" = "%@ тому";
 "formatter.date.relative.left" = "Залишилося %@";
 
+//"reminder.status.overdue" = "Overdue";
+
 "reminder.options.button" = "Опції";
 "reminder.options.complete" = "Завершено";
 "reminder.options.remind" = "Нагадати %@";
 
-"event_details.participant.organizer" = "організатор";
-"event_details.participant.me" = "я";
+"event.details.participant.organizer" = "організатор";
+"event.details.participant.me" = "я";
 
-"event_status.accepted" = "Прийнято";
-"event_status.maybe" = "Можливо";
-"event_status.declined" = "Відхилено";
-"event_status.pending" = "Очікується";
+"event.all_day" = "Весь день";
 
-"event_action.open" = "Відкрити";
-"event_action.join" = "Приєднатися";
-"event_action.skip" = "Пропустити";
-"event_action.accept" = "Прийняти";
-"event_action.maybe" = "Можливо";
-"event_action.decline" = "Відхилити";
+"event.status.accepted" = "Прийнято";
+"event.status.maybe" = "Можливо";
+"event.status.declined" = "Відхилено";
+"event.status.pending" = "Очікується";
+
+"event.action.open" = "Відкрити";
+"event.action.join" = "Приєднатися";
+"event.action.skip" = "Пропустити";
+"event.action.accept" = "Прийняти";
+"event.action.maybe" = "Можливо";
+"event.action.decline" = "Відхилити";
 
 "tooltips.navigation.prev_month" = "Попередній місяць";
 "tooltips.navigation.today" = "Сьогодні";

--- a/Calendr/Assets/zh-Hans.lproj/Localizable.strings
+++ b/Calendr/Assets/zh-Hans.lproj/Localizable.strings
@@ -78,30 +78,33 @@
 "settings.keyboard.global_shortcuts.open_next_reminder" = "打开下一个提醒";
 "settings.keyboard.global_shortcuts.open_next_reminder_options" = "下一个提醒选项";
 
-"formatter.date.all_day" = "全天";
 "formatter.date.today" = "今日";
 "formatter.date.relative.in" = "在 %@ 内";
 "formatter.date.relative.ago" = "%@ 之前";
 "formatter.date.relative.left" = "还剩 %@";
 
+//"reminder.status.overdue" = "Overdue";
+
 "reminder.options.button" = "选项";
 "reminder.options.complete" = "完成";
 "reminder.options.remind" = "%@提醒";
 
-"event_details.participant.organizer" = "发起人";
-"event_details.participant.me" = "我";
+"event.details.participant.organizer" = "发起人";
+"event.details.participant.me" = "我";
 
-"event_status.accepted" = "已接受";
-"event_status.maybe" = "也许";
-"event_status.declined" = "已拒绝";
-"event_status.pending" = "等待中";
+"event.all_day" = "全天";
 
-"event_action.open" = "打开";
-"event_action.join" = "加入";
-"event_action.skip" = "跳过";
-"event_action.accept" = "接受";
-"event_action.maybe" = "也许";
-"event_action.decline" = "拒绝";
+"event.status.accepted" = "已接受";
+"event.status.maybe" = "也许";
+"event.status.declined" = "已拒绝";
+"event.status.pending" = "等待中";
+
+"event.action.open" = "打开";
+"event.action.join" = "加入";
+"event.action.skip" = "跳过";
+"event.action.accept" = "接受";
+"event.action.maybe" = "也许";
+"event.action.decline" = "拒绝";
 
 "tooltips.navigation.prev_month" = "上个月";
 "tooltips.navigation.today" = "今天";

--- a/Calendr/Assets/zh-Hant-TW.lproj/Localizable.strings
+++ b/Calendr/Assets/zh-Hant-TW.lproj/Localizable.strings
@@ -78,30 +78,33 @@
 "settings.keyboard.global_shortcuts.open_next_reminder" = "打開下一個提醒";
 "settings.keyboard.global_shortcuts.open_next_reminder_options" = "下一個提醒選項";
 
-"formatter.date.all_day" = "全天";
 "formatter.date.today" = "今天";
 "formatter.date.relative.in" = "在 %@ 之後";
 "formatter.date.relative.ago" = "%@ 之前";
 "formatter.date.relative.left" = "剩下 %@";
 
+//"reminder.status.overdue" = "Overdue";
+
 "reminder.options.button" = "選項";
 "reminder.options.complete" = "完成";
 "reminder.options.remind" = "提醒 %@";
 
-"event_details.participant.organizer" = "組織者";
-"event_details.participant.me" = "我";
+"event.details.participant.organizer" = "組織者";
+"event.details.participant.me" = "我";
 
-"event_status.accepted" = "已接受";
-"event_status.maybe" = "可能";
-"event_status.declined" = "已拒絕";
-"event_status.pending" = "待定";
+"event.all_day" = "全天";
 
-"event_action.open" = "打開";
-"event_action.join" = "加入";
-"event_action.skip" = "跳過";
-"event_action.accept" = "接受";
-"event_action.maybe" = "可能";
-"event_action.decline" = "拒絕";
+"event.status.accepted" = "已接受";
+"event.status.maybe" = "可能";
+"event.status.declined" = "已拒絕";
+"event.status.pending" = "待定";
+
+"event.action.open" = "打開";
+"event.action.join" = "加入";
+"event.action.skip" = "跳過";
+"event.action.accept" = "接受";
+"event.action.maybe" = "可能";
+"event.action.decline" = "拒絕";
 
 "tooltips.navigation.prev_month" = "前一個月";
 "tooltips.navigation.today" = "今天";

--- a/Calendr/Components/Popover.swift
+++ b/Calendr/Components/Popover.swift
@@ -85,7 +85,7 @@ class Popover: NSObject, PopoverWindowDelegate {
         window.level = .popUpMenu
         window.isReleasedWhenClosed = false
         window.isMovableByWindowBackground = false
-        window.animationBehavior = .utilityWindow
+        window.animationBehavior = .none
         window._delegate = self
 
         frameObserver = window.observe(\.frame) { [weak view] window, _ in

--- a/Calendr/Events/ContextMenu/EventOptionsViewModel.swift
+++ b/Calendr/Events/ContextMenu/EventOptionsViewModel.swift
@@ -114,7 +114,7 @@ extension EventAction: ContextMenuAction {
         switch self {
         case .open:
             return Icons.Calendar.calendar
-        
+
         case .link(let link, let isInProgress):
             let icon = if link.isMeeting {
                 isInProgress ? Icons.Event.video_fill : Icons.Event.video
@@ -137,17 +137,17 @@ extension EventAction: ContextMenuAction {
     var title: String {
         switch self {
         case .open:
-            return Strings.EventAction.open
+            return Strings.Event.Action.open
         case .link(let link, _):
-            return link.isMeeting ? Strings.EventAction.join : link.url.domain ?? "???"
+            return link.isMeeting ? Strings.Event.Action.join : link.url.domain ?? "???"
         case .skip:
-            return Strings.EventAction.skip
+            return Strings.Event.Action.skip
         case .status(.accept):
-            return Strings.EventAction.accept
+            return Strings.Event.Action.accept
         case .status(.maybe):
-            return Strings.EventAction.maybe
+            return Strings.Event.Action.maybe
         case .status(.decline):
-            return Strings.EventAction.decline
+            return Strings.Event.Action.decline
         }
     }
 }

--- a/Calendr/Events/ContextMenu/ReminderOptionsViewModel.swift
+++ b/Calendr/Events/ContextMenu/ReminderOptionsViewModel.swift
@@ -107,7 +107,7 @@ extension ReminderAction: ContextMenuAction {
     var title: String {
         switch self {
         case .open:
-            return Strings.EventAction.open
+            return Strings.Event.Action.open
         case .complete:
             return Strings.Reminder.Options.complete
         case .remind(let dateComponents):

--- a/Calendr/Events/EventDetails/EventDetailsViewController.swift
+++ b/Calendr/Events/EventDetails/EventDetailsViewController.swift
@@ -213,16 +213,16 @@ class EventDetailsViewController: NSViewController, PopoverDelegate, MKMapViewDe
         switch viewModel.type {
 
         case .event(.accepted):
-            addEventStatusButton(icon: Icons.EventStatus.accepted, color: .systemGreen, title: Strings.EventStatus.accepted)
+            addEventStatusButton(icon: Icons.EventStatus.accepted, color: .systemGreen, title: Strings.Event.Status.accepted)
 
         case .event(.maybe):
-            addEventStatusButton(icon: Icons.EventStatus.maybe, color: .systemOrange, title: Strings.EventStatus.maybe)
+            addEventStatusButton(icon: Icons.EventStatus.maybe, color: .systemOrange, title: Strings.Event.Status.maybe)
 
         case .event(.pending):
-            addEventStatusButton(icon: Icons.EventStatus.pending, color: .systemGray, title: Strings.EventStatus.pending)
+            addEventStatusButton(icon: Icons.EventStatus.pending, color: .systemGray, title: Strings.Event.Status.pending)
 
         case .event(.declined):
-            addEventStatusButton(icon: Icons.EventStatus.declined, color: .systemRed, title: Strings.EventStatus.declined)
+            addEventStatusButton(icon: Icons.EventStatus.declined, color: .systemRed, title: Strings.Event.Status.declined)
 
         case .reminder:
             addReminderOptionsButton()
@@ -257,7 +257,7 @@ class EventDetailsViewController: NSViewController, PopoverDelegate, MKMapViewDe
 
     private func addOpenButton() {
 
-        openButton.title = Strings.EventAction.open
+        openButton.title = Strings.Event.Action.open
 
         setButtonStyle(openButton)
 
@@ -266,7 +266,7 @@ class EventDetailsViewController: NSViewController, PopoverDelegate, MKMapViewDe
 
     private func addSkipButton() {
 
-        skipButton.title = Strings.EventAction.skip
+        skipButton.title = Strings.Event.Action.skip
         skipButton.image = Icons.Event.skip.with(scale: .small)
         skipButton.imagePosition = .imageTrailing
 
@@ -562,11 +562,11 @@ class EventDetailsViewController: NSViewController, PopoverDelegate, MKMapViewDe
             var info: String = participant.name
 
             if participant.isOrganizer {
-                info += " (\(Strings.EventDetails.Participant.organizer))"
+                info += " (\(Strings.Event.Details.Participant.organizer))"
             }
 
             if participant.isCurrentUser {
-                info += " (\(Strings.EventDetails.Participant.me))"
+                info += " (\(Strings.Event.Details.Participant.me))"
             }
 
             let label = Label(text: info, font: .small)

--- a/Calendr/Events/EventList/EventListView.swift
+++ b/Calendr/Events/EventList/EventListView.swift
@@ -29,6 +29,15 @@ class EventListView: NSView {
         setUpBindings()
     }
 
+    func childRect(at index: Int) -> NSRect? {
+        let children = contentStackView.arrangedSubviews
+        guard index > 0, index < children.count else {
+            return nil
+        }
+        layoutSubtreeIfNeeded()
+        return children[index].frame
+    }
+
     private func setUpAccessibility() {
 
         guard BuildConfig.isUITesting else { return }
@@ -51,6 +60,7 @@ class EventListView: NSView {
     private func setUpBindings() {
 
         viewModel.asObservable()
+            .map(\.items)
             .observe(on: MainScheduler.instance)
             .withUnretained(self)
             .map { view, items in
@@ -71,6 +81,7 @@ class EventListView: NSView {
             .disposed(by: disposeBag)
 
         viewModel.asObservable()
+            .map(\.items)
             .observe(on: MainScheduler.instance)
             .map(\.isEmpty)
             .bind(to: rx.isHidden)

--- a/Calendr/Events/EventList/EventListView.swift
+++ b/Calendr/Events/EventList/EventListView.swift
@@ -59,8 +59,7 @@ class EventListView: NSView {
 
     private func setUpBindings() {
 
-        viewModel.asObservable()
-            .map(\.items)
+        viewModel.items
             .observe(on: MainScheduler.instance)
             .withUnretained(self)
             .map { view, items in
@@ -80,8 +79,7 @@ class EventListView: NSView {
             .bind(to: contentStackView.rx.arrangedSubviews)
             .disposed(by: disposeBag)
 
-        viewModel.asObservable()
-            .map(\.items)
+        viewModel.items
             .observe(on: MainScheduler.instance)
             .map(\.isEmpty)
             .bind(to: rx.isHidden)

--- a/Calendr/Events/EventList/EventListView.swift
+++ b/Calendr/Events/EventList/EventListView.swift
@@ -31,7 +31,7 @@ class EventListView: NSView {
 
     func childRect(at index: Int) -> NSRect? {
         let children = contentStackView.arrangedSubviews
-        guard index > 0, index < children.count else {
+        guard index >= 0, index < children.count else {
             return nil
         }
         layoutSubtreeIfNeeded()

--- a/Calendr/Events/EventList/EventListViewModel.swift
+++ b/Calendr/Events/EventList/EventListViewModel.swift
@@ -45,6 +45,7 @@ class EventListViewModel {
     private let userDefaults: UserDefaults
     private let settings: EventListSettings
     private let scheduler: SchedulerType
+    private let eventsScheduler: SchedulerType
 
     private let dateFormatter: DateFormatter
     private let relativeFormatter: RelativeDateTimeFormatter
@@ -68,7 +69,8 @@ class EventListViewModel {
         workspace: WorkspaceServiceProviding,
         userDefaults: UserDefaults,
         settings: EventListSettings,
-        scheduler: SchedulerType
+        scheduler: SchedulerType,
+        eventsScheduler: SchedulerType
     ) {
         self.isShowingDetails = isShowingDetails
         self.dateProvider = dateProvider
@@ -79,6 +81,7 @@ class EventListViewModel {
         self.userDefaults = userDefaults
         self.settings = settings
         self.scheduler = scheduler
+        self.eventsScheduler = eventsScheduler
 
         dateFormatter = DateFormatter(calendar: dateProvider.calendar)
         dateFormatter.dateStyle = .short
@@ -203,7 +206,7 @@ class EventListViewModel {
             settings: settings,
             isShowingDetails: isShowingDetails.asObserver(),
             isTodaySelected: isTodaySelected,
-            scheduler: scheduler
+            scheduler: eventsScheduler
         )
     }
 

--- a/Calendr/Events/EventList/EventListViewModel.swift
+++ b/Calendr/Events/EventList/EventListViewModel.swift
@@ -18,13 +18,13 @@ private extension EventListItem {
     var event: EventViewModel? { if case .event(let event) = self { event } else { nil } }
 }
 
-struct EventListSummaryItem {
+struct EventListSummaryItem: Equatable {
     let colors: Set<NSColor>
     let label: String
     let count: Int
 }
 
-struct EventListSummary {
+struct EventListSummary: Equatable {
     let overdue: EventListSummaryItem
     let allday: EventListSummaryItem
     let today: EventListSummaryItem

--- a/Calendr/Events/EventList/EventView.swift
+++ b/Calendr/Events/EventList/EventView.swift
@@ -194,7 +194,8 @@ class EventView: NSView {
         progress.wantsLayer = true
         progress.layer?.backgroundColor = NSColor.red.cgColor.copy(alpha: 0.7)
         progress.height(equalTo: 1)
-        progress.width(equalTo: self)
+        progress.leading(equalTo: self)
+        progress.trailing(equalTo: self)
     }
 
     private func setUpBindings() {

--- a/Calendr/Events/EventList/EventViewModel.swift
+++ b/Calendr/Events/EventList/EventViewModel.swift
@@ -17,6 +17,8 @@ class EventViewModel {
     let barStyle: EventBarStyle
     let type: EventType
     let isDeclined: Bool
+    let isAllDay: Bool
+    let start: Date
     let link: EventLink?
     let priority: String?
 
@@ -75,6 +77,8 @@ class EventViewModel {
         color = event.calendar.color
         type = event.type
         isDeclined = event.status ~= .declined
+        isAllDay = event.isAllDay
+        start = event.start
         barStyle = event.status ~= .maybe ? .bordered : .filled
         link = event.detectLink(using: workspace)
 

--- a/Calendr/Events/EventList/EventViewModel.swift
+++ b/Calendr/Events/EventList/EventViewModel.swift
@@ -224,7 +224,7 @@ class EventViewModel {
                 .take(until: isPast.matching(true))
 
         } else {
-            isPast = .just(true)
+            isPast = .just(secondsToEnd <= 0)
             clock = .just(())
         }
 

--- a/Calendr/Extensions/Rx+Helpers.swift
+++ b/Calendr/Extensions/Rx+Helpers.swift
@@ -40,7 +40,7 @@ extension ObservableType {
 
     func lastValue() -> Element? {
         var value: Element? = nil
-        bind { value = $0 }.dispose()
+        _ = bind { value = $0 }
         return value
     }
 }

--- a/Calendr/Main/MainViewController.swift
+++ b/Calendr/Main/MainViewController.swift
@@ -182,7 +182,8 @@ class MainViewController: NSViewController {
             workspace: workspace,
             userDefaults: userDefaults,
             settings: settingsViewModel,
-            scheduler: WallTimeScheduler()
+            scheduler: WallTimeScheduler.instance,
+            eventsScheduler: WallTimeScheduler.instance
         )
 
         eventListView = EventListView(viewModel: eventListViewModel)

--- a/Calendr/Previews/EventListViewPreview.swift
+++ b/Calendr/Previews/EventListViewPreview.swift
@@ -59,7 +59,8 @@ struct EventListViewPreview: PreviewProvider {
                 workspace: workspace,
                 userDefaults: .init(),
                 settings: settings,
-                scheduler: MainScheduler.instance
+                scheduler: MainScheduler.instance,
+                eventsScheduler: MainScheduler.instance
             )
         )
         .preview()

--- a/Calendr/Schedulers/WallTimeScheduler.swift
+++ b/Calendr/Schedulers/WallTimeScheduler.swift
@@ -15,6 +15,8 @@ import RxSwift
 */
 class WallTimeScheduler: SchedulerType {
 
+    static let instance = WallTimeScheduler()
+
     var now: RxTime { Date() }
 
     func scheduleRelative<StateType>(_ state: StateType, dueTime: RxTimeInterval,

--- a/CalendrTests/EventListViewModelTests.swift
+++ b/CalendrTests/EventListViewModelTests.swift
@@ -53,12 +53,12 @@ class EventListViewModelTests: XCTestCase {
         let yesterday = dateProvider.calendar.date(byAdding: .day, value: -1, to: date)!
 
         return [
-            .make(start: date + 70, end: date + 200, title: "Event 1", isAllDay: false),
-            .make(start: date + 70, end: date + 100, title: "Event 2", isAllDay: false),
-            .make(start: date, end: date + 10, title: "All day 1", isAllDay: true),
-            .make(start: date, end: date + 10, title: "Event 3", isAllDay: false),
-            .make(start: date, end: date + 10, title: "All day 2", isAllDay: true),
-            .make(start: yesterday, end: date + 10, title: "Multi day", isAllDay: false)
+            .make(start: date + 70, end: date + 200, title: "Event 1", isAllDay: false, calendar: .color(.red)),
+            .make(start: date + 70, end: date + 100, title: "Event 2", isAllDay: false, calendar: .color(.red)),
+            .make(start: date, end: date + 10, title: "All day 1", isAllDay: true, calendar: .color(.red)),
+            .make(start: date, end: date + 10, title: "Event 3", isAllDay: false, calendar: .color(.yellow)),
+            .make(start: date, end: date + 10, title: "All day 2", isAllDay: true, calendar: .color(.yellow)),
+            .make(start: yesterday, end: date + 10, title: "Multi day", isAllDay: false, calendar: .color(.blue))
         ]
     }
 
@@ -100,6 +100,13 @@ class EventListViewModelTests: XCTestCase {
             .event("All day 1"),
             .event("All day 2"),
         ])
+
+        let summary = EventListSummary(
+            overdue: .overdue([], 0),
+            allday: .allday([.red, .yellow], 2),
+            today: .today([], 0)
+        )
+        XCTAssertEqual(viewModel.summary.lastValue(), summary)
     }
 
     func testEventList_noAllDay_shouldNotShowAllDaySection() {
@@ -114,6 +121,12 @@ class EventListViewModelTests: XCTestCase {
             .event("Event 2"),
             .event("Event 1")
         ])
+
+        XCTAssertEqual(viewModel.summary.lastValue(), EventListSummary(
+            overdue: .overdue([], 0),
+            allday: .allday([], 0),
+            today: .today([.blue, .yellow, .red], 4)
+        ))
     }
 
     func testEventList_isToday_shouldShowTodaySection() {
@@ -131,6 +144,12 @@ class EventListViewModelTests: XCTestCase {
             .event("Event 2"),
             .event("Event 1")
         ])
+
+        XCTAssertEqual(viewModel.summary.lastValue(), EventListSummary(
+            overdue: .overdue([], 0),
+            allday: .allday([.red, .yellow], 2),
+            today: .today([.blue, .yellow, .red], 4)
+        ))
     }
 
     func testEventList_isNotToday_shouldShowDateSection() {
@@ -149,6 +168,12 @@ class EventListViewModelTests: XCTestCase {
             .event("Event 2"),
             .event("Event 1")
         ])
+
+        XCTAssertEqual(viewModel.summary.lastValue(), EventListSummary(
+            overdue: .overdue([], 0),
+            allday: .allday([.red, .yellow], 2),
+            today: .today([.blue, .yellow, .red], 4)
+        ))
     }
 
     func testEventList_withHidePastEventsEnabled_isNotToday_shouldNotHideEvents() {
@@ -168,6 +193,12 @@ class EventListViewModelTests: XCTestCase {
             .event("Event 2"),
             .event("Event 1")
         ])
+
+        XCTAssertEqual(viewModel.summary.lastValue(), EventListSummary(
+            overdue: .overdue([], 0),
+            allday: .allday([.red, .yellow], 2),
+            today: .today([.blue, .yellow, .red], 4)
+        ))
     }
 
     func testEventList_withHidePastEventsEnabled_isToday_shouldHidePastEvents() {
@@ -187,6 +218,12 @@ class EventListViewModelTests: XCTestCase {
             .event("Event 1")
         ])
 
+        XCTAssertEqual(viewModel.summary.lastValue(), EventListSummary(
+            overdue: .overdue([], 0),
+            allday: .allday([.red, .yellow], 2),
+            today: .today([.red], 2)
+        ))
+
         dateProvider.add(1, .minute)
         scheduler.advance(1, .minute)
 
@@ -197,6 +234,12 @@ class EventListViewModelTests: XCTestCase {
             .section("Today"),
             .event("Event 1")
         ])
+
+        XCTAssertEqual(viewModel.summary.lastValue(), EventListSummary(
+            overdue: .overdue([], 0),
+            allday: .allday([.red, .yellow], 2),
+            today: .today([.red], 1)
+        ))
     }
 
     func testEventList_withFadePastEventsEnabled_shouldFadePastSections() {
@@ -245,15 +288,33 @@ class EventListViewModelTests: XCTestCase {
 
         XCTAssertEqual(sectionsFaded, [false, false])
 
+        XCTAssertEqual(viewModel.summary.lastValue(), EventListSummary(
+            overdue: .overdue([], 0),
+            allday: .allday([.red, .yellow], 2),
+            today: .today([.blue, .yellow, .red, .clear], 5)
+        ))
+
         dateProvider.add(1, .hour)
         eventsScheduler.advance(1, .hour)
 
         XCTAssertEqual(sectionsFaded, [true, false])
 
+        XCTAssertEqual(viewModel.summary.lastValue(), EventListSummary(
+            overdue: .overdue([], 0),
+            allday: .allday([.red, .yellow], 2),
+            today: .today([.clear], 1)
+        ))
+
         dateProvider.add(1, .hour)
         eventsScheduler.advance(1, .hour)
 
         XCTAssertEqual(sectionsFaded, [true, true])
+
+        XCTAssertEqual(viewModel.summary.lastValue(), EventListSummary(
+            overdue: .overdue([], 0),
+            allday: .allday([.red, .yellow], 2),
+            today: .today([], 0)
+        ))
     }
 
     func testEventList_withFadePastEventsEnabled_shouldNotScheduleRefreshes() {
@@ -305,9 +366,9 @@ class EventListViewModelTests: XCTestCase {
         eventsSubject.onNext(
             testEvents() +
             [
-                .make(start: yesterday, title: "Overdue 1", type: .reminder(completed: false)),
-                .make(start: yesterday + 10, title: "Overdue 2", type: .reminder(completed: false)),
-                .make(start: twoDaysAgo, title: "All day overdue", isAllDay: true, type: .reminder(completed: false)),
+                .make(start: yesterday, title: "Overdue 1", type: .reminder(completed: false), calendar: .color(.purple)),
+                .make(start: yesterday + 10, title: "Overdue 2", type: .reminder(completed: false), calendar: .color(.green)),
+                .make(start: twoDaysAgo, title: "All day overdue", isAllDay: true, type: .reminder(completed: false), calendar: .color(.green)),
             ]
         )
 
@@ -327,6 +388,12 @@ class EventListViewModelTests: XCTestCase {
             .event("Event 2"),
             .event("Event 1")
         ])
+
+        XCTAssertEqual(viewModel.summary.lastValue(), EventListSummary(
+            overdue: .overdue([.green, .purple], 3),
+            allday: .allday([.red, .yellow], 2),
+            today: .today([.blue, .yellow, .red], 4)
+        ))
     }
 
     func testEventList_withOverdueReminders_withShowOverdueDisabled_shouldNotShowOverdueReminders() {
@@ -339,9 +406,9 @@ class EventListViewModelTests: XCTestCase {
         eventsSubject.onNext(
             testEvents() +
             [
-                .make(start: yesterday, title: "Overdue 1", type: .reminder(completed: false)),
-                .make(start: yesterday + 10, title: "Overdue 2", type: .reminder(completed: false)),
-                .make(start: twoDaysAgo, title: "All day overdue", isAllDay: true, type: .reminder(completed: false)),
+                .make(start: yesterday, title: "Overdue 1", type: .reminder(completed: false), calendar: .color(.purple)),
+                .make(start: yesterday + 10, title: "Overdue 2", type: .reminder(completed: false), calendar: .color(.green)),
+                .make(start: twoDaysAgo, title: "All day overdue", isAllDay: true, type: .reminder(completed: false), calendar: .color(.green)),
             ]
         )
 
@@ -356,6 +423,12 @@ class EventListViewModelTests: XCTestCase {
             .event("Event 2"),
             .event("Event 1")
         ])
+
+        XCTAssertEqual(viewModel.summary.lastValue(), EventListSummary(
+            overdue: .overdue([], 0),
+            allday: .allday([.red, .yellow], 2),
+            today: .today([.blue, .yellow, .red], 4)
+        ))
     }
 
     func testEventList_withOverdueReminders_isNotToday_shouldShowNormally() {
@@ -367,12 +440,12 @@ class EventListViewModelTests: XCTestCase {
 
         eventsSubject.onNext(
             [
-                .make(start: date, end: date + 10, title: "Event 1"),
-                .make(start: date + 60, end: date + 120, title: "Event 2"),
-                .make(start: date + 200, title: "Overdue", type: .reminder(completed: false)),
-                .make(start: date + 300, title: "Completed", type: .reminder(completed: true)),
-                .make(start: date, title: "All day event", isAllDay: true),
-                .make(start: date, title: "All day overdue", isAllDay: true, type: .reminder(completed: false))
+                .make(start: date, end: date + 10, title: "Event 1", calendar: .color(.red)),
+                .make(start: date + 60, end: date + 120, title: "Event 2", calendar: .color(.red)),
+                .make(start: date + 200, title: "Overdue", type: .reminder(completed: false), calendar: .color(.yellow)),
+                .make(start: date + 300, title: "Completed", type: .reminder(completed: true), calendar: .color(.yellow)),
+                .make(start: date, title: "All day event", isAllDay: true, calendar: .color(.red)),
+                .make(start: date, title: "All day overdue", isAllDay: true, type: .reminder(completed: false), calendar: .color(.red))
             ]
         )
 
@@ -387,6 +460,12 @@ class EventListViewModelTests: XCTestCase {
             .event("Overdue"),
             .event("Completed")
         ])
+
+        XCTAssertEqual(viewModel.summary.lastValue(), EventListSummary(
+            overdue: .overdue([], 0),
+            allday: .allday([.red], 2),
+            today: .today([.red, .yellow], 4)
+        ))
     }
 
     func testEventList_withCompletedReminders_isToday_shouldShowNormally() {
@@ -395,12 +474,12 @@ class EventListViewModelTests: XCTestCase {
 
         eventsSubject.onNext(
             [
-                .make(start: date, end: date + 10, title: "Event 1"),
-                .make(start: date + 60, end: date + 120, title: "Event 2"),
-                .make(start: date + 200, title: "Reminder 1", type: .reminder(completed: true)),
-                .make(start: date + 300, title: "Reminder 2", type: .reminder(completed: false)),
-                .make(start: date, title: "All day event", isAllDay: true),
-                .make(start: date, title: "All day overdue", isAllDay: true, type: .reminder(completed: false))
+                .make(start: date, end: date + 10, title: "Event 1", calendar: .color(.red)),
+                .make(start: date + 60, end: date + 120, title: "Event 2", calendar: .color(.red)),
+                .make(start: date + 200, title: "Reminder 1", type: .reminder(completed: true), calendar: .color(.yellow)),
+                .make(start: date + 300, title: "Reminder 2", type: .reminder(completed: false), calendar: .color(.green)),
+                .make(start: date, title: "All day event", isAllDay: true, calendar: .color(.red)),
+                .make(start: date, title: "All day overdue", isAllDay: true, type: .reminder(completed: false), calendar: .color(.yellow))
             ]
         )
 
@@ -415,6 +494,12 @@ class EventListViewModelTests: XCTestCase {
             .event("Reminder 1"),
             .event("Reminder 2")
         ])
+
+        XCTAssertEqual(viewModel.summary.lastValue(), EventListSummary(
+            overdue: .overdue([], 0),
+            allday: .allday([.red, .yellow], 2),
+            today: .today([.red, .green], 3)
+        ))
     }
 
 
@@ -426,12 +511,12 @@ class EventListViewModelTests: XCTestCase {
 
         eventsSubject.onNext(
             [
-                .make(start: date, end: date + 10, title: "Event 1"),
-                .make(start: date + 60, end: date + 120, title: "Event 2"),
-                .make(start: date + 200, title: "Reminder 1", type: .reminder(completed: true)),
-                .make(start: date + 300, title: "Reminder 2", type: .reminder(completed: false)),
-                .make(start: date, title: "All day event", isAllDay: true),
-                .make(start: date, title: "All day overdue", isAllDay: true, type: .reminder(completed: false))
+                .make(start: date, end: date + 10, title: "Event 1", calendar: .color(.red)),
+                .make(start: date + 60, end: date + 120, title: "Event 2", calendar: .color(.red)),
+                .make(start: date + 200, title: "Reminder 1", type: .reminder(completed: true), calendar: .color(.yellow)),
+                .make(start: date + 300, title: "Reminder 2", type: .reminder(completed: false), calendar: .color(.green)),
+                .make(start: date, title: "All day event", isAllDay: true, calendar: .color(.red)),
+                .make(start: date, title: "All day overdue", isAllDay: true, type: .reminder(completed: false), calendar: .color(.yellow))
             ]
         )
 
@@ -445,5 +530,33 @@ class EventListViewModelTests: XCTestCase {
             .interval("3m"),
             .event("Reminder 2")
         ])
+
+        XCTAssertEqual(viewModel.summary.lastValue(), EventListSummary(
+            overdue: .overdue([], 0),
+            allday: .allday([.red, .yellow], 2),
+            today: .today([.red, .green], 3)
+        ))
+    }
+}
+
+private extension EventListSummaryItem {
+
+    static func overdue(_ colors: Set<NSColor>, _ count: Int) -> EventListSummaryItem {
+        .init(colors: colors, label: Strings.Reminder.Status.overdue, count: count)
+    }
+
+    static func allday(_ colors: Set<NSColor>, _ count: Int) -> EventListSummaryItem {
+        .init(colors: colors, label: Strings.Event.allDay, count: count)
+    }
+
+    static func today(_ colors: Set<NSColor>, _ count: Int) -> EventListSummaryItem {
+        .init(colors: colors, label: Strings.Formatter.Date.today, count: count)
+    }
+}
+
+private extension CalendarModel {
+
+    static func color(_ color: NSColor) -> CalendarModel {
+        .make(color: color)
     }
 }

--- a/CalendrTests/EventListViewModelTests.swift
+++ b/CalendrTests/EventListViewModelTests.swift
@@ -64,9 +64,9 @@ class EventListViewModelTests: XCTestCase {
 
     override func setUp() {
 
-        viewModel.asObservable()
+        viewModel.items
             .bind { [weak self] in
-                self?.eventListItems = $0.items.map { item in
+                self?.eventListItems = $0.map { item in
                     switch item {
                     case .event(let viewModel):
                         return .event(viewModel.title)
@@ -225,10 +225,10 @@ class EventListViewModelTests: XCTestCase {
 
         var sectionsFaded: [Bool]?
 
-        viewModel.asObservable()
+        viewModel.items
             .flatMap {
                 Observable.combineLatest(
-                    $0.items.compactMap { item -> Observable<Bool>? in
+                    $0.compactMap { item -> Observable<Bool>? in
                         switch item {
                         case .interval(_, let fade):
                             return fade

--- a/CalendrTests/EventOptionsViewModelTests.swift
+++ b/CalendrTests/EventOptionsViewModelTests.swift
@@ -231,8 +231,8 @@ class EventOptionsViewModelTests: XCTestCase {
     }
 
     func testEventLinkAction_isMeeting() {
-        XCTAssertEqual(EventAction.link(.zoomLink, isInProgress: false).title, Strings.EventAction.join)
-        
+        XCTAssertEqual(EventAction.link(.zoomLink, isInProgress: false).title, Strings.Event.Action.join)
+
         XCTAssertEqual(EventAction.link(.zoomLink, isInProgress: false).icon, Icons.Event.video)
         
         XCTAssertEqual(

--- a/MISSING_TRANSLATIONS.md
+++ b/MISSING_TRANSLATIONS.md
@@ -1,8 +1,23 @@
 # The following languages have missing translations
 Language|Count
 -|-
-[Chinese - 中文 - (zh-Hant-TW)](Calendr/Assets/zh-Hant-TW.lproj/Localizable.strings)|5
-[Chinese - 中文 - (zh-Hans)](Calendr/Assets/zh-Hans.lproj/Localizable.strings)|5
+[German - Deutsch - (de)](Calendr/Assets/de.lproj/Localizable.strings)|1
+[Chinese - 中文 - (zh-Hant-TW)](Calendr/Assets/zh-Hant-TW.lproj/Localizable.strings)|6
+[Greek - Ελληνικά - (el)](Calendr/Assets/el.lproj/Localizable.strings)|1
+[Chinese - 中文 - (zh-Hans)](Calendr/Assets/zh-Hans.lproj/Localizable.strings)|6
+[Japanese - 日本語 - (ja)](Calendr/Assets/ja.lproj/Localizable.strings)|1
+[Albanian - shqip - (sq)](Calendr/Assets/sq.lproj/Localizable.strings)|1
+[Ukrainian - українська - (uk)](Calendr/Assets/uk.lproj/Localizable.strings)|1
+[Spanish - español - (es)](Calendr/Assets/es.lproj/Localizable.strings)|1
+[Italian - italiano - (it)](Calendr/Assets/it.lproj/Localizable.strings)|1
+[Slovak - slovenčina - (sk)](Calendr/Assets/sk.lproj/Localizable.strings)|1
+[Swedish - svenska - (sv)](Calendr/Assets/sv.lproj/Localizable.strings)|1
+[Czech - čeština - (cs)](Calendr/Assets/cs.lproj/Localizable.strings)|1
+[Korean - 한국어 - (ko)](Calendr/Assets/ko.lproj/Localizable.strings)|1
+[Turkish - Türkçe - (tr)](Calendr/Assets/tr.lproj/Localizable.strings)|1
+[Russian - русский - (ru)](Calendr/Assets/ru.lproj/Localizable.strings)|1
+[French - français - (fr)](Calendr/Assets/fr.lproj/Localizable.strings)|1
+[Portuguese - português - (pt)](Calendr/Assets/pt.lproj/Localizable.strings)|1
 
 Feel free to open a new issue or pull request with the missing values.
 


### PR DESCRIPTION
The event list will now scroll to the next pending event and show a summary at the top indicating the amount of `Overdue`, `All day` and `Today` events, only when the current date is selected and scroll is available.

Closes #372 


