### PR TITLE
Add Sentry badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![homebrew](https://img.shields.io/badge/Homebrew-gray?logo=homebrew&logoColor=FBB040)](https://github.com/pakerwreah/Calendr/issues/217)
 [![release](https://img.shields.io/github/v/release/pakerwreah/Calendr)](https://github.com/pakerwreah/Calendr/releases/latest)
 [![bitrise](https://img.shields.io/bitrise/9fa2e96dc9458fbb?label=Unit%20Tests&logo=bitrise&token=iAJgn0FMJzmMP4ALCi0KdQ)](https://app.bitrise.io/app/9fa2e96dc9458fbb)
+[![sentry](https://img.shields.io/badge/Sentry-purple?logo=sentry&logoColor=white)](https://github.com/pakerwreah/Calendr/issues/183)
 [![buy-me-a-coffee](https://img.shields.io/badge/Buy_Me_a_Coffee-ffdd00?logo=buy-me-a-coffee&logoColor=black)](https://buymeacoffee.com/pakerwreah)
 
 Menu bar calendar for macOS


### PR DESCRIPTION
Add Sentry badge pointing to FAQ where the user can know more about the telemetry.
Closes #410