### PR TITLE
Translated missing text into Russian 🇷🇺

### DIFF
--- a/Calendr/Assets/ru.lproj/Localizable.strings
+++ b/Calendr/Assets/ru.lproj/Localizable.strings
@@ -4,6 +4,7 @@
 
   Created by Petros Dhespollari on 08/02/2025.
   Updated by Pavel Bychko on 08/02/2025.
+  Updated by Roman Kolosov on 11/05/2025.
 */
 
 "quit" = "Выход";
@@ -22,8 +23,8 @@
 "auto_update.install" = "Установить";
 "auto_update.replace.message" = "Подтвердите местоположение приложения, чтобы предоставить разрешение на его замену";
 
-//"attachments.open.message" = "Calendr needs permission to access your attachments";
-//"attachments.open.authorize" = "Authorize access to attachments";
+"attachments.open.message" = "Приложению Calendr нужно разрешение на доступ к вложениям";
+"attachments.open.authorize" = "Разрешить доступ к вложениям";
 
 "settings.title" = "Настройки";
 "settings.tab.general" = "Общее";
@@ -87,7 +88,7 @@
 "formatter.date.relative.ago" = "%@ назад";
 "formatter.date.relative.left" = "%@ осталось";
 
-//"reminder.status.overdue" = "Overdue";
+"reminder.status.overdue" = "Просрочено";
 
 "reminder.options.button" = "Опции";
 "reminder.options.complete" = "Полный";

--- a/Calendr/Assets/ru.lproj/Localizable.strings
+++ b/Calendr/Assets/ru.lproj/Localizable.strings
@@ -84,9 +84,9 @@
 "settings.keyboard.global_shortcuts.open_next_reminder_options" = "Открыть настройки следующего напоминания";
 
 "formatter.date.today" = "Сегодня";
-"formatter.date.relative.in" = "в %@";
+"formatter.date.relative.in" = "через %@";
 "formatter.date.relative.ago" = "%@ назад";
-"formatter.date.relative.left" = "%@ осталось";
+"formatter.date.relative.left" = "осталось %@";
 
 "reminder.status.overdue" = "Просрочено";
 

--- a/MISSING_TRANSLATIONS.md
+++ b/MISSING_TRANSLATIONS.md
@@ -14,7 +14,6 @@ Language|Count
 [Czech - čeština - (cs)](Calendr/Assets/cs.lproj/Localizable.strings)|3
 [Korean - 한국어 - (ko)](Calendr/Assets/ko.lproj/Localizable.strings)|3
 [Turkish - Türkçe - (tr)](Calendr/Assets/tr.lproj/Localizable.strings)|3
-[Russian - русский - (ru)](Calendr/Assets/ru.lproj/Localizable.strings)|3
 [French - français - (fr)](Calendr/Assets/fr.lproj/Localizable.strings)|3
 
 Feel free to open a new issue or pull request with the missing values.


### PR DESCRIPTION
I just wanted to say thank you for creating such a fantastic app. I really enjoy using it!

I made a small localization update by translating a small part of the app to Russian. I hope this helps improve the experience for users who speak this language.

Right now it looks a bit strange. `"formatter.date.relative.in"` shows that the event will occur in “Название _**в**_ ХХ мин”, although “Название _**через**_ ХХ мин” would be more appropriate.

I'd also like to clarify how feasible it is to change `"formatter.date.relative.left"` by swapping `%@` from the beginning to the end?
`"formatter.date.relative.left"` looks a bit odd, it's now “Название ХХ мин _**осталось**_”, although we usually use “Название _**осталось**_ ХХ мин”.