### PR TITLE
Fix high CPU usage in macOS 26.1 with dual display

### DIFF
--- a/Calendr.xcodeproj/project.pbxproj
+++ b/Calendr.xcodeproj/project.pbxproj
@@ -1687,7 +1687,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 1.18.1;
+				MARKETING_VERSION = 1.18.2;
 				PRODUCT_BUNDLE_IDENTIFIER = br.paker.Calendr;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Calendr/Config/Calendr-Bridging-Header.h";
@@ -1719,7 +1719,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 1.18.1;
+				MARKETING_VERSION = 1.18.2;
 				PRODUCT_BUNDLE_IDENTIFIER = br.paker.Calendr;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Calendr/Config/Calendr-Bridging-Header.h";

--- a/Calendr/Main/MainViewController.swift
+++ b/Calendr/Main/MainViewController.swift
@@ -731,13 +731,19 @@ class MainViewController: NSViewController {
 
     private func setUpEventStatusItem(item: NSStatusItem, view: NextEventView, viewModel: NextEventViewModel, clickHandler: StatusItemClickHandler) {
         guard
-            let statusBarButton = item.button
+            let statusBarButton = item.button,
+            // ⚠️ There's a bug in macOS 26.1 that causes CPU usage to spike when using multiple displays.
+            //    When we attach the event view to superview?.superview, we make it disappear on inactive screens.
+            //    Unfortunately, if Apple doesn't fix this issue, we can't show it, because the app becomes unusable.
+
+            /// When that happens, Console.app starts spamming:
+            /// ```
+            /// [com.apple.controlcenter:...] Sending action(s) in update: NSSceneFenceAction
+            /// ```
+            let statusBarContainer = if #available(macOS 26.1, *) { statusBarButton.superview?.superview } else { statusBarButton }
         else { return }
 
-        // uncomment this if we want the view to fade on inactive screens
-        // statusBarButton.image = NSImage()
-
-        statusBarButton.addSubview(view)
+        statusBarContainer.addSubview(view)
 
         view.leading(equalTo: statusBarButton)
         view.top(equalTo: statusBarButton)


### PR DESCRIPTION
⚠️ There's a bug in macOS 26.1 (RC) that causes CPU usage to spike when using multiple displays.

When that happens, Console.app starts spamming:
```
[com.apple.controlcenter:...] Sending action(s) in update: NSSceneFenceAction
```

Unfortunately, if Apple does not fix this issue, we can't show next event on inactive displays.
This PR essentially rolls back #455 which was shipped with v1.17.3

Fix #501 