### PR TITLE
Fix light/dark next event text color

### DIFF
--- a/Calendr.xcodeproj/project.pbxproj
+++ b/Calendr.xcodeproj/project.pbxproj
@@ -1719,7 +1719,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 1.19.0;
+				MARKETING_VERSION = 1.19.1;
 				PRODUCT_BUNDLE_IDENTIFIER = br.paker.Calendr;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Calendr/Config/Calendr-Bridging-Header.h";
@@ -1751,7 +1751,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 1.19.0;
+				MARKETING_VERSION = 1.19.1;
 				PRODUCT_BUNDLE_IDENTIFIER = br.paker.Calendr;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Calendr/Config/Calendr-Bridging-Header.h";

--- a/Calendr/MenuBar/NextEventView.swift
+++ b/Calendr/MenuBar/NextEventView.swift
@@ -13,7 +13,7 @@ class NextEventView: NSView {
     private let disposeBag = DisposeBag()
 
     private let updateSubject = PublishSubject<Void>()
-    let viewSnapshot = BehaviorSubject<NSImage?>(value: nil)
+    let viewUpdated: Observable<Void>
 
     private let viewModel: NextEventViewModel
 
@@ -25,6 +25,10 @@ class NextEventView: NSView {
     init(viewModel: NextEventViewModel) {
 
         self.viewModel = viewModel
+
+        viewUpdated = updateSubject
+            .debounce(.milliseconds(50), scheduler: MainScheduler.instance)
+            .startWith(())
 
         let scaling = viewModel.textScaling.track(with: updateSubject)
 
@@ -77,12 +81,6 @@ class NextEventView: NSView {
     }
 
     private func setUpBindings() {
-
-        updateSubject
-            .debounce(.milliseconds(50), scheduler: MainScheduler.instance)
-            .map { [weak self] in self?.asImage() }
-            .bind(to: viewSnapshot)
-            .disposed(by: disposeBag)
 
         Observable.combineLatest(
             viewModel.barStyle,


### PR DESCRIPTION
Fix #509 

The text color should now react to the wallpaper.

Unfortunately, because it is now an image, we cannot have 2 different appearances as we did before.
This is an edge-case where the user might have a light wallpaper in one screen and a dark wallpaper in the other.

Ideally we should just use a subview, but Apple decided to break `macOS 26.1` menu bar rendering. 😔