### PR TITLE
Try to improve menu bar blurriness

### DIFF
--- a/Calendr.xcodeproj/project.pbxproj
+++ b/Calendr.xcodeproj/project.pbxproj
@@ -96,6 +96,7 @@
 		34702150259E163000827AE7 /* CalendarModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3470214F259E163000827AE7 /* CalendarModel.swift */; };
 		34702168259E761100827AE7 /* Calendar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34702167259E761100827AE7 /* Calendar.swift */; };
 		3470654B292EFCF90079C68A /* NSTextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3470654A292EFCF90079C68A /* NSTextView.swift */; };
+		347098972EC4099D004A3D5E /* FloatingPoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 347098962EC4099C004A3D5E /* FloatingPoint.swift */; };
 		34711F6F2D16261800A89C72 /* MockWorkspaceServiceProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34711F6E2D16261400A89C72 /* MockWorkspaceServiceProvider.swift */; };
 		3477E70C2C67A6A9008D3844 /* Sentry in Frameworks */ = {isa = PBXBuildFile; productRef = 3477E70B2C67A6A9008D3844 /* Sentry */; };
 		3477E7102C67C15A008D3844 /* AppEnvironment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3477E70F2C67C15A008D3844 /* AppEnvironment.swift */; };
@@ -348,6 +349,7 @@
 		3470214F259E163000827AE7 /* CalendarModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarModel.swift; sourceTree = "<group>"; };
 		34702167259E761100827AE7 /* Calendar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Calendar.swift; sourceTree = "<group>"; };
 		3470654A292EFCF90079C68A /* NSTextView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NSTextView.swift; sourceTree = "<group>"; };
+		347098962EC4099C004A3D5E /* FloatingPoint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FloatingPoint.swift; sourceTree = "<group>"; };
 		34711F6E2D16261400A89C72 /* MockWorkspaceServiceProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockWorkspaceServiceProvider.swift; sourceTree = "<group>"; };
 		3477E70F2C67C15A008D3844 /* AppEnvironment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppEnvironment.swift; sourceTree = "<group>"; };
 		3477F3CD25FAE56A008EA888 /* EventDetailsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventDetailsViewModel.swift; sourceTree = "<group>"; };
@@ -780,6 +782,7 @@
 				34924CED259FD064009C3450 /* DateFormatter.swift */,
 				34651F5325E22A3900518C5A /* DateIntervalFormatter.swift */,
 				34EDE71A2AC46515007C5854 /* Error.swift */,
+				347098962EC4099C004A3D5E /* FloatingPoint.swift */,
 				34E60D6226A0EA32004DA082 /* NSAccessibilityProtocol.swift */,
 				34E60D6026A0D6D6004DA082 /* NSAccessibilityProtocol+Rx.swift */,
 				34B5A09625B0F8A500F7F7ED /* NSButton.swift */,
@@ -1393,6 +1396,7 @@
 				3408F17625FAAA4B00C1EAD4 /* EventDetailsViewController.swift in Sources */,
 				3470654B292EFCF90079C68A /* NSTextView.swift in Sources */,
 				34F24D242C64F335001F99A9 /* AppConstants.swift in Sources */,
+				347098972EC4099D004A3D5E /* FloatingPoint.swift in Sources */,
 				341692C225F1AA570019E8A8 /* WallTimeScheduler.swift in Sources */,
 				34B5A09725B0F8A500F7F7ED /* NSButton.swift in Sources */,
 				3443D9782EB1241E00476D4B /* MapBlackListViewModel.swift in Sources */,

--- a/Calendr/Extensions/FloatingPoint.swift
+++ b/Calendr/Extensions/FloatingPoint.swift
@@ -1,0 +1,12 @@
+//
+//  FloatingPoint.swift
+//  Calendr
+//
+//  Created by Paker on 12/11/2025.
+//
+
+extension FloatingPoint {
+    func rounded(to step: Self) -> Self {
+        (self / step).rounded() * step
+    }
+}

--- a/Calendr/MenuBar/StatusItemIconFactory.swift
+++ b/Calendr/MenuBar/StatusItemIconFactory.swift
@@ -14,7 +14,7 @@ enum StatusItemIconFactory {
         let borderWidth: CGFloat = 2
         let radius: CGFloat = 2.5
         let rect = CGRect(x: 0, y: 0, width: size + borderWidth, height: size)
-        let insetX = 2.5 * textScaling
+        let insetX = (2.5 * textScaling).rounded(to: 0.5)
 
         let size = switch style {
         case .calendar, .date:
@@ -96,12 +96,13 @@ enum StatusItemIconFactory {
         let date = formatter.string(from: dateProvider.now)
         let paragraph = NSMutableParagraphStyle()
         paragraph.alignment = .center
-        let fontSize = 0.6 * rect.height
+        let fontSize = (0.6 * rect.height).rounded(to: 0.5)
+        let middleY = rect.height / 2 - fontSize / 2
         NSAttributedString(string: date, attributes: [
             .font: NSFont.systemFont(ofSize: fontSize, weight: .medium),
             .foregroundColor: NSColor.red,
             .paragraphStyle: paragraph
-        ]).draw(in: rect.offsetBy(dx: 0, dy: rect.height / 2 - fontSize / 2))
+        ]).draw(in: rect.offsetBy(dx: 0, dy: middleY))
     }
 
     static func drawDayOfWeekAndDate(rect: CGRect, insetX: CGFloat, textScaling: Double, dateProvider: DateProviding) {
@@ -112,19 +113,19 @@ enum StatusItemIconFactory {
         let paragraph = NSMutableParagraphStyle()
         paragraph.alignment = .center
 
-        let fontSize = 0.6 * rect.height
-        let middleY = rect.height / 2 - fontSize / 2 + 1
-        let middleYSpread = fontSize / 2.5 + 1
+        let fontSize = (0.6 * rect.height).rounded(to: 0.5)
+        let middleY = rect.height / 2
+        let spacing: CGFloat = 0.5
 
         run {
             formatter.dateFormat = "E"
             let date = formatter.string(from: dateProvider.now).uppercased().trimmingCharacters(in: ["."])
             NSAttributedString(string: date, attributes: [
-                .font: NSFont.systemFont(ofSize: fontSize, weight: .bold),
+                .font: NSFont.systemFont(ofSize: fontSize, weight: .semibold),
                 .foregroundColor: NSColor.red,
                 .paragraphStyle: paragraph
             ])
-            .draw(in: rect.offsetBy(dx: insetX, dy: middleY - middleYSpread).insetBy(dx: -insetX, dy: 0))
+            .draw(in: rect.offsetBy(dx: insetX, dy: -spacing).insetBy(dx: -insetX, dy: 0))
         }
 
         run {
@@ -135,7 +136,7 @@ enum StatusItemIconFactory {
                 .foregroundColor: NSColor.red,
                 .paragraphStyle: paragraph
             ])
-            .draw(in: rect.offsetBy(dx: insetX, dy: middleY + middleYSpread).insetBy(dx: 0, dy: -1))
+            .draw(in: rect.offsetBy(dx: insetX, dy: middleY + spacing).insetBy(dx: 0, dy: -1))
         }
     }
 }

--- a/Calendr/MenuBar/StatusItemViewModel.swift
+++ b/Calendr/MenuBar/StatusItemViewModel.swift
@@ -99,7 +99,7 @@ class StatusItemViewModel {
 
             let showDate = !title.isEmpty
 
-            let iconSize: CGFloat = 12 * textScaling
+            let iconSize: CGFloat = (12 * textScaling).rounded(to: 0.5)
 
             if hasBirthdays {
                 birthdayIcon = .init(size: iconSize - 2)
@@ -146,7 +146,7 @@ class StatusItemViewModel {
             }
 
             let title = text.isEmpty ? nil : NSAttributedString(string: text, attributes: [
-                .font: NSFont.systemFont(ofSize: 10 * textScaling, weight: .medium)
+                .font: NSFont.systemFont(ofSize: (10 * textScaling).rounded(to: 0.5), weight: .medium)
             ])
 
             if let title {


### PR DESCRIPTION
This is far from perfect, but at least we have more scaling steps where the text is not blurry.

This scaling idea was born from an accessibility point of view, not customization, so it was never meant to be resized.

Maybe... just maybe... we could convert this into a view and draw it to an image, as we do for the next event.

That would probably prevent the texts from dancing around when we change the scale, because they would be anchored to the view using auto layout constraints, and appkit would probably do a better job than me.

However, that would be a complete rewrite of this feature, and I'm really not in the mood.

Close: #530 