### PR TITLE
Fix next event position not persisted (again)

### DIFF
--- a/Calendr/Mocks/MockLocalStorage.swift
+++ b/Calendr/Mocks/MockLocalStorage.swift
@@ -9,7 +9,7 @@ import Foundation
 
 #if DEBUG
 
-class InMemoryStorage: LocalStorage {
+class InMemoryStorage: NSObject, LocalStorage {
     private var storage: [String: Any] = [:]
     private var registeredDefaults: [String: Any] = [:]
 
@@ -23,12 +23,20 @@ class InMemoryStorage: LocalStorage {
         }
     }
 
+    override func value(forKey name: String) -> Any? {
+        object(forKey: name)
+    }
+
     func set(_ value: Any?, forKey name: String) {
+        willChangeValue(forKey: name)
         storage[name] = value
+        didChangeValue(forKey: name)
     }
 
     func removeObject(forKey name: String) {
+        willChangeValue(forKey: name)
         storage.removeValue(forKey: name)
+        didChangeValue(forKey: name)
     }
 
     func object(forKey name: String) -> Any? {

--- a/Calendr/Providers/LocalStorageProvider.swift
+++ b/Calendr/Providers/LocalStorageProvider.swift
@@ -6,8 +6,9 @@
 //
 
 import RxSwift
+import RxCocoa
 
-protocol LocalStorage {
+protocol LocalStorage: NSObject {
 
     func register(defaults: [String : Any])
 
@@ -38,7 +39,7 @@ protocol LocalStorage {
 /// If we add this constraint directly to the protocol, we have to deal with "existential types" which are absolute nightmares
 class LocalStorageProvider: NSObject, LocalStorage {
 
-    private let storage: LocalStorage
+    fileprivate let storage: LocalStorage
 
     init(storage: LocalStorage) {
         self.storage = storage
@@ -128,5 +129,13 @@ extension LocalStorageProvider {
     func withDefaults() -> Self {
         registerDefaultPrefs(in: self)
         return self
+    }
+}
+
+extension Reactive where Base: LocalStorageProvider {
+
+    func observe<Element: KVORepresentable>(_ type: Element.Type, _ keyPath: String, options: KeyValueObservingOptions = [.new, .initial]) -> Observable<Element?> {
+
+        (base.storage as NSObject).rx.observe(type, keyPath, options: options)
     }
 }


### PR DESCRIPTION
Fix #540 

Regression #486 caused by #500

The local storage abstraction broke observation in `NextEventViewModel`:
```swift
localStorage.rx.observe(Int.self, preferredPositionKey, options: [.new])
```