### PR TITLE
Add vscode build and debug support

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,12 @@
+{
+    "configurations": [
+        {
+            "type": "swift",
+            "request": "launch",
+            "name": "Debug Calendr",
+            "cwd": "${workspaceFolder}/.build/Calendr.app/Contents/MacOS",
+            "program": "Calendr",
+            "preLaunchTask": "Assemble Debug Calendr",
+        }
+    ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,50 @@
+{
+    "version": "2.0.0",
+    "options": {
+        "env": {
+            "SRCROOT": "${workspaceFolder}",
+            "PROJECT_DIR": "${workspaceFolder}",
+            "TARGET_NAME": "Calendr"
+        },
+    },
+    "tasks": [
+        {
+            "label": "Sync Localizations",
+            "type": "shell",
+            "options": {
+                "cwd": "Calendr/Tools",
+            },
+            "command": "swift",
+            "args": [
+                "SyncLocalizations.swift"
+            ]
+        },
+        {
+            "label": "Generate Strings",
+            "type": "shell",
+            "command": "swiftgen",
+            "options": {
+                "cwd": "Calendr/Config",
+            },
+            "args": [
+                "--config",
+                "swiftgen.yml"
+            ]
+        },
+        {
+            "label": "Assemble Debug Calendr",
+            "type": "shell",
+            "command": "./assemble.sh",
+            "group": {
+                "kind": "build"
+            },
+            "args": [
+                "debug"
+            ],
+            "dependsOn": [
+                "Sync Localizations",
+                "Generate Strings"
+            ]
+        }
+    ]
+}

--- a/Calendr/Config/swiftgen.yml
+++ b/Calendr/Config/swiftgen.yml
@@ -1,7 +1,10 @@
+input_dir: ${PROJECT_DIR}/${TARGET_NAME}
+output_dir: ${PROJECT_DIR}/${TARGET_NAME}
+
 strings:
-  inputs: ${PROJECT_DIR}/${TARGET_NAME}/Assets/en.lproj
+  inputs: Assets/en.lproj
   outputs:
     - templateName: structured-swift5
-      output: ${PROJECT_DIR}/${TARGET_NAME}/Constants/Strings.generated.swift
+      output: Constants/Strings.generated.swift
       params:
         enumName: Strings

--- a/assemble.sh
+++ b/assemble.sh
@@ -2,17 +2,24 @@
 set -e
 shopt -s extglob
 
+MODE=$1
+
+if [[ $MODE != "release" && $MODE != "debug" ]]; then
+    echo "❌ Invalid mode. Must be 'release' or 'debug'"
+    exit 1
+fi
+
 if [[ ! -e "Package.swift" || ! -e "Calendr.xcodeproj" ]]; then
     echo "❌ This script must be run from the project root directory"
     exit 1
 fi
 
 # Build the Binary
-swift build -c release
+swift build -c $MODE
 
 # Configuration
 CONFIG_DIR="Calendr/Config"
-BUILD_DIR="$(swift build -c release --show-bin-path)"
+BUILD_DIR="$(swift build -c $MODE --show-bin-path)"
 APP_BUNDLE=".build/Calendr.app"
 CONTENTS="$APP_BUNDLE/Contents"
 


### PR DESCRIPTION
### VS Code integration

- Add VS Code configuration files for building and debugging the Calendr app.
- Renamed `assembleRelease.sh` to `assemble.sh` and update it to accept `debug`/`release` arguments.