### PR TITLE
Update token in homebrew workflow

### DIFF
--- a/.github/workflows/update-homebrew-tap.yml
+++ b/.github/workflows/update-homebrew-tap.yml
@@ -13,8 +13,6 @@ on:
 jobs:
   update-cask:
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
 
     steps:
       - name: Set Release Version from Input
@@ -30,7 +28,7 @@ jobs:
         with:
           repository: pakerwreah/homebrew-calendr
           path: homebrew-calendr
-          token: ${{ secrets.ACTIONS_GITHUB_TOKEN }}
+          token: ${{ secrets.UPDATE_HOMEBREW_CALENDR }}
 
       - name: Calculate sha256 checksum
         id: checksum


### PR DESCRIPTION
Updated token and removed write permissions.
The workflow now uses a fine-grained token with only access to `pakerwreah/homebrew-calendr`.