### PR TITLE
Fix crash when AppleScript fails to open calendar

### DIFF
--- a/Calendr.xcodeproj/project.pbxproj
+++ b/Calendr.xcodeproj/project.pbxproj
@@ -223,7 +223,7 @@
 			attributes = {
 				BuildIndependentTargetsInParallel = YES;
 				LastSwiftUpdateCheck = 1250;
-				LastUpgradeCheck = 2640;
+				LastUpgradeCheck = 2650;
 				TargetAttributes = {
 					34427696269B5CA4004CFE1C = {
 						CreatedOnToolsVersion = 12.5.1;
@@ -600,7 +600,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 1.20.7;
+				MARKETING_VERSION = 1.20.8;
 				PRODUCT_BUNDLE_IDENTIFIER = br.paker.Calendr;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Calendr/ObjC/Calendr-Bridging-Header.h";
@@ -634,7 +634,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 1.20.7;
+				MARKETING_VERSION = 1.20.8;
 				PRODUCT_BUNDLE_IDENTIFIER = br.paker.Calendr;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Calendr/ObjC/Calendr-Bridging-Header.h";

--- a/Calendr.xcodeproj/xcshareddata/xcschemes/Calendr.xcscheme
+++ b/Calendr.xcodeproj/xcshareddata/xcschemes/Calendr.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "2640"
+   LastUpgradeVersion = "2650"
    version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Calendr/Automation/AppleScript.swift
+++ b/Calendr/Automation/AppleScript.swift
@@ -23,23 +23,33 @@ enum ScriptError: LocalizedError {
 }
 
 protocol ScriptRunner {
-    func run(_ source: String) async throws
+    @MainActor
+    func run(_ source: String) throws
 }
 
 class AppleScriptRunner: ScriptRunner {
 
-    func run(_ source: String) async throws {
+    func run(_ source: String) throws {
         assert(!source.contains("delay "), "Don't use 'delay', it causes memory leak.")
 
         var errorInfo: NSDictionary?
         guard let script = NSAppleScript(source: source) else {
             throw ScriptError.source
         }
-        guard script.compileAndReturnError(&errorInfo) else {
-            throw ScriptError.compile(error: errorInfo?[NSAppleScript.errorMessage] as? String)
+        script.compileAndReturnError(&errorInfo)
+        if let errorInfo {
+            throw ScriptError.compile(error: errorInfo.errorMessage)
         }
-        if script.executeAndReturnError(&errorInfo).description.isEmpty {
-            throw ScriptError.execute(error: errorInfo?[NSAppleScript.errorMessage] as? String)
+        script.executeAndReturnError(&errorInfo)
+        if let errorInfo {
+            throw ScriptError.execute(error: errorInfo.errorMessage)
         }
+    }
+}
+
+private extension NSDictionary {
+
+    var errorMessage: String? {
+        self[NSAppleScript.errorMessage] as? String
     }
 }

--- a/Calendr/Mocks/MockScriptRunner.swift
+++ b/Calendr/Mocks/MockScriptRunner.swift
@@ -11,7 +11,7 @@ class MockScriptRunner: ScriptRunner {
 
     var didRunScript: ((_ source: String) throws -> Void)?
 
-    func run(_ source: String) async throws {
+    func run(_ source: String) throws {
         try didRunScript?(source)
     }
 }


### PR DESCRIPTION
Fix #614 

**Disclaimer**: I was not able to reproduce the issue.

Not sure if this is going to actually solve it, but there's no reason for the runner to be async, and probably unsafe, as we can tell.

We now also check the error properly, instead of accessing the description, which might also have triggered the exception in some cases.