### PR TITLE
Update Korean translations 🇰🇷

### DIFF
--- a/Calendr/Assets/ko.lproj/Localizable.strings
+++ b/Calendr/Assets/ko.lproj/Localizable.strings
@@ -62,7 +62,7 @@
 "settings.calendar.calendar_app_view_mode" = "캘린더 앱 보기 모드";
 "settings.calendar.default_calendar_app" = "기본 캘린더 앱";
 
-"settings.calendar.event_dots" = "일정 점";
+"settings.calendar.event_dots" = "일정 점 표시 방식";
 "settings.calendar.event_dots.none" = "없음";
 "settings.calendar.event_dots.single_neutral" = "기본";
 "settings.calendar.event_dots.single_highlighted" = "강조";

--- a/Calendr/Assets/ko.lproj/Localizable.strings
+++ b/Calendr/Assets/ko.lproj/Localizable.strings
@@ -1,4 +1,4 @@
-/* 
+/*
   Localizable.strings
   Calendr
 
@@ -19,15 +19,15 @@
 "auto_update.updated_to" = "버전 %@ 으로 업데이트되었습니다.";
 "auto_update.downloading" = "버전 %@ 다운로드 중";
 "auto_update.install" = "설치";
-"auto_update.replace.message" = "앱을 대체할 수 있도록 애플리케이션 경로를 확인해주세요";
-//"auto_update.replace.error" = "You must not change the installation directory";
+"auto_update.replace.message" = "앱을 교체할 수 있도록 앱 위치를 확인해 주세요";
+"auto_update.replace.error" = "설치 위치를 변경할 수 없습니다";
 
-//"auto_update.failed.check" = "Failed to check for update";
-//"auto_update.failed.download" = "Failed to download update";
-//"auto_update.failed.install" = "Failed to install update";
+"auto_update.failed.check" = "업데이트 확인 실패";
+"auto_update.failed.download" = "업데이트 다운로드 실패";
+"auto_update.failed.install" = "업데이트 설치 실패";
 
-//"attachments.open.message" = "Calendr needs permission to access your attachments";
-//"attachments.open.authorize" = "Authorize access to attachments";
+"attachments.open.message" = "첨부 파일에 접근하려면 Calendr에 권한이 필요합니다";
+"attachments.open.authorize" = "첨부 파일 접근 권한 허용";
 
 "settings.title" = "설정";
 "settings.tab.general" = "일반";
@@ -42,7 +42,7 @@
 "settings.menu_bar.show_date" = "날짜 표시";
 "settings.menu_bar.show_background" = "불투명한 배경 표시";
 "settings.menu_bar.date_format_custom" = "사용자 지정";
-//"settings.menu_bar.open_on_hover" = "Open on mouse hover";
+"settings.menu_bar.open_on_hover" = "마우스 호버 시 열기";
 
 "settings.next_event" = "다음 일정";
 "settings.next_event.show_next_event" = "다음 일정 표시";
@@ -52,31 +52,31 @@
 "settings.next_event.detect_notch" = "노치 디스플레이에서 길이 조정";
 
 "settings.calendar" = "캘린더";
-//"settings.calendar.show_month_outline" = "Show month outline";
+"settings.calendar.show_month_outline" = "월 외곽선 표시";
 "settings.calendar.show_week_numbers" = "주 번호 표시";
 "settings.calendar.preserve_selected_date" = "숨길 때 선택한 날짜 유지";
 "settings.calendar.show_declined_events" = "거절한 일정 표시";
-"settings.calendar.show_declined_events_tooltip" = "이 기능은 기본 캘린더 앱에서도 활성화해야 작동합니다. (메뉴바-보기-거부된 이벤트 보기)";
-"settings.calendar.date_hover_option" = "⌥ 키를 누르고 날짜 호버 시 미리보기";
-//"settings.calendar.week_count" = "Visible weeks";
+"settings.calendar.show_declined_events_tooltip" = "기본 캘린더 앱에서도 활성화해야 작동합니다. (메뉴바 → 보기 → 거부된 이벤트 보기)";
+"settings.calendar.date_hover_option" = "⌥ 키를 누른 채 날짜 위에 호버하여 미리보기";
+"settings.calendar.week_count" = "표시할 주 수";
 "settings.calendar.calendar_app_view_mode" = "캘린더 앱 보기 모드";
-//"settings.calendar.default_calendar_app" = "Default calendar app";
+"settings.calendar.default_calendar_app" = "기본 캘린더 앱";
 
-//"settings.calendar.event_dots" = "Event dots";
-//"settings.calendar.event_dots.none" = "none";
-//"settings.calendar.event_dots.single_neutral" = "neutral";
-//"settings.calendar.event_dots.single_highlighted" = "highlighted";
-//"settings.calendar.event_dots.multiple" = "multiple";
+"settings.calendar.event_dots" = "일정 점";
+"settings.calendar.event_dots.none" = "없음";
+"settings.calendar.event_dots.single_neutral" = "기본";
+"settings.calendar.event_dots.single_highlighted" = "강조";
+"settings.calendar.event_dots.multiple" = "여러 개";
 
 "settings.events" = "일정";
 "settings.events.show_map" = "지도 및 날씨 표시";
 "settings.events.show_overdue_reminders" = "기한이 지난 미리 알림 표시";
-//"settings.events.show_all_day_details" = "Show all-day events details";
+"settings.events.show_all_day_details" = "하루 종일 일정 상세 표시";
 "settings.events.show_finished_events" = "완료된 일정 표시";
 "settings.events.show_recurrence_indicator" = "반복 일정 표시";
 "settings.events.force_local_time_zone" = "모든 일정을 로컬 시간대로 표시";
-//"settings.events.show_event_list_summary" = "Show event list summary";
-//"settings.events.show_future_events" = "Show future events";
+"settings.events.show_event_list_summary" = "일정 목록 요약 표시";
+"settings.events.show_future_events" = "예정된 일정 표시";
 
 "settings.appearance.transparency" = "투명도";
 "settings.appearance.accessibility" = "접근성";
@@ -94,8 +94,8 @@
 
 "settings.keyboard.global_shortcuts.title" = "전역 바로가기";
 "settings.keyboard.global_shortcuts.open_calendar" = "캘린더 열기";
-"settings.keyboard.global_shortcuts.open_next_event" = "다음 이벤트 열기";
-"settings.keyboard.global_shortcuts.open_next_event_options" = "다음 이벤트 옵션";
+"settings.keyboard.global_shortcuts.open_next_event" = "다음 일정 열기";
+"settings.keyboard.global_shortcuts.open_next_event_options" = "다음 일정 옵션";
 "settings.keyboard.global_shortcuts.open_next_reminder" = "다음 미리 알림 열기";
 "settings.keyboard.global_shortcuts.open_next_reminder_options" = "다음 미리 알림 옵션";
 
@@ -104,24 +104,24 @@
 "formatter.date.relative.ago" = "%@ 전";
 "formatter.date.relative.left" = "%@ 남음";
 
-//"formatter.events.plural" = "%@ events";
-//"formatter.reminders.plural" = "%@ reminders";
+"formatter.events.plural" = "일정 %@개";
+"formatter.reminders.plural" = "미리 알림 %@개";
 
-//"reminder.status.overdue" = "Overdue";
+"reminder.status.overdue" = "기한 지남";
 
 "reminder.options.button" = "옵션";
 "reminder.options.complete" = "완료";
 "reminder.options.remind" = "%@ 후 알림";
 
-//"reminder.editor.headline" = "New Reminder";
-//"reminder.editor.title" = "Title";
-//"reminder.editor.save" = "Save";
+"reminder.editor.headline" = "새 미리 알림";
+"reminder.editor.title" = "제목";
+"reminder.editor.save" = "저장";
 
-//"reminder.editor.confirm.continue" = "Continue editing";
-//"reminder.editor.confirm.discard" = "Discard all changes";
+"reminder.editor.confirm.continue" = "계속 편집";
+"reminder.editor.confirm.discard" = "변경사항 모두 취소";
 
-//"map_black_list.headline" = "Hide map if location contains any of these words";
-//"map_black_list.new_item_text" = "New Item";
+"map_black_list.headline" = "위치에 다음 단어가 포함된 경우 지도 숨기기";
+"map_black_list.new_item_text" = "새 항목";
 
 "event.details.participant.organizer" = "주최자";
 "event.details.participant.me" = "나";
@@ -147,7 +147,7 @@
 "tooltips.navigation.next_month" = "다음 달";
 
 "tooltips.toolbar.stay_open" = "열어두기";
-//"tooltips.toolbar.create" = "Create";
+"tooltips.toolbar.create" = "생성";
 "tooltips.toolbar.open_calendar" = "캘린더 열기";
 "tooltips.toolbar.open_reminders" = "미리 알림 열기";
 "tooltips.toolbar.open_menu" = "메뉴 열기";

--- a/MISSING_TRANSLATIONS.md
+++ b/MISSING_TRANSLATIONS.md
@@ -14,7 +14,6 @@ Language|Count
 [Slovak - slovenčina - (sk)](Calendr/Assets/sk.lproj/Localizable.strings)|2
 [Swedish - svenska - (sv)](Calendr/Assets/sv.lproj/Localizable.strings)|29
 [Czech - čeština - (cs)](Calendr/Assets/cs.lproj/Localizable.strings)|29
-[Korean - 한국어 - (ko)](Calendr/Assets/ko.lproj/Localizable.strings)|29
 [Turkish - Türkçe - (tr)](Calendr/Assets/tr.lproj/Localizable.strings)|3
 [Polish - polski - (pl)](Calendr/Assets/pl.lproj/Localizable.strings)|2
 [Russian - русский - (ru)](Calendr/Assets/ru.lproj/Localizable.strings)|5


### PR DESCRIPTION
Adds the 29 missing Korean translations and applies a small set of refinements.

### New translations
- `auto_update.replace.error`, `auto_update.failed.{check,download,install}`
- `attachments.open.{message,authorize}`
- `settings.menu_bar.open_on_hover`
- `settings.calendar.{show_month_outline,week_count,default_calendar_app}`
- `settings.calendar.event_dots` + 4 sub-keys
- `settings.events.{show_all_day_details,show_event_list_summary,show_future_events}`
- `formatter.{events,reminders}.plural`
- `reminder.status.overdue`
- `reminder.editor.{headline,title,save}`
- `reminder.editor.confirm.{continue,discard}`
- `map_black_list.{headline,new_item_text}`
- `tooltips.toolbar.create`

### Refinements to existing strings
- `settings.keyboard.global_shortcuts.open_next_event{,_options}`: `이벤트` → `일정` for in-app consistency (the file uses `일정` 9 times elsewhere).
- `auto_update.replace.message`: smoother phrasing (`대체` → `교체`).
- `settings.calendar.show_declined_events_tooltip`: shortened to match the English brevity; the parenthetical menu path quotes Apple's actual macOS Calendar menu text (`거부된 이벤트 보기`) verbatim so users can find it.
- `settings.calendar.date_hover_option`: more natural Korean phrasing.
- `reminder.editor.confirm.discard`: added `모두` to match `Discard all changes`.
- `attachments.open.message`: added the `Calendr에` subject for clarity.

### Style notes
The original translator chose `일정` (instead of Apple's `이벤트`) and `거절` (instead of Apple's `거부`) for app-internal text. This PR preserves those choices and only deviates from them in the one place that directly cites a macOS Calendar menu label.