### PR TITLE
Mock auto launcher

### DIFF
--- a/Calendr/Main/MainViewController.swift
+++ b/Calendr/Main/MainViewController.swift
@@ -81,7 +81,7 @@ class MainViewController: NSViewController {
 
     init(
         deeplink: Observable<URL>,
-        autoLauncher: AutoLauncher,
+        autoLauncher: AutoLaunching,
         workspace: WorkspaceServiceProviding,
         calendarService: CalendarServiceProviding,
         geocoder: GeocodeServiceProviding,

--- a/Calendr/Mocks/MockAutoLauncher.swift
+++ b/Calendr/Mocks/MockAutoLauncher.swift
@@ -1,0 +1,16 @@
+//
+//  MockAutoLauncher.swift
+//  Calendr
+//
+//  Created by Paker on 21/05/2026.
+//
+import Foundation
+
+#if DEBUG
+
+class MockAutoLauncher: NSObject, AutoLaunching {
+    @objc dynamic var isEnabled: Bool = false
+    func syncStatus() { }
+}
+
+#endif

--- a/Calendr/Settings/AutoLauncher.swift
+++ b/Calendr/Settings/AutoLauncher.swift
@@ -8,7 +8,12 @@
 import AppKit
 import ServiceManagement
 
-class AutoLauncher: NSObject {
+@objc protocol AutoLaunching: AnyObject where Self: NSObject {
+    @objc dynamic var isEnabled: Bool { get set }
+    func syncStatus()
+}
+
+class AutoLauncher: NSObject, AutoLaunching {
 
     @objc dynamic var isEnabled: Bool = false {
         didSet {

--- a/Calendr/Settings/SettingsViewModel.swift
+++ b/Calendr/Settings/SettingsViewModel.swift
@@ -224,12 +224,12 @@ class SettingsViewModel:
 
     let dateFormatPlaceholder = AppConstants.defaultCustomDateFormat
 
-    private let autoLauncher: AutoLauncher
+    private let autoLauncher: AutoLaunching
     private let dateProvider: DateProviding
     private let localStorage: LocalStorageProvider
 
     init(
-        autoLauncher: AutoLauncher,
+        autoLauncher: some AutoLaunching,
         dateProvider: DateProviding,
         workspace: WorkspaceServiceProviding,
         localStorage: LocalStorageProvider,

--- a/CalendrTests/SettingsViewModelTests.swift
+++ b/CalendrTests/SettingsViewModelTests.swift
@@ -13,7 +13,7 @@ class SettingsViewModelTests: XCTestCase {
 
     let disposeBag = DisposeBag()
 
-    let autoLauncher = AutoLauncher()
+    let autoLauncher = MockAutoLauncher()
     let dateProvider = MockDateProvider()
     let workspace = MockWorkspaceServiceProvider()
     let localStorage = MockLocalStorageProvider()


### PR DESCRIPTION
`xctest` was being added as a login item when running tests via `swift test`