### PR TITLE
Clean up unnecessary code from swiftui hosting controller

### DIFF
--- a/Calendr/Components/HostingWindowController.swift
+++ b/Calendr/Components/HostingWindowController.swift
@@ -29,15 +29,8 @@ class HostingWindowController<RootView: View>: NSHostingController<RootView>, NS
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
-    
-    override func viewDidLoad() {
-        super.viewDidLoad()
 
-        guard let window = view.window else {
-            return assertionFailure()
-        }
-        window.delegate = self
-    }
+    // IMPORTANT: loadView and viewDidLoad are never called here
 
     override func viewWillAppear() {
         super.viewWillAppear()

--- a/Calendr/Settings/SettingsViewController.swift
+++ b/Calendr/Settings/SettingsViewController.swift
@@ -112,7 +112,6 @@ class SettingsViewController: NSTabViewController, NSWindowDelegate {
         setUpAccessibilityWindow()
 
         window.styleMask.remove(.resizable)
-        window.delegate = self
 
         NSApp.activate(ignoringOtherApps: true)
     }


### PR DESCRIPTION
Also remove the unnecessary window delegate assignment from settings.
Today I learned that it's done automatically when you add `NSWindowDelegate` to a `NSViewController`.

That's why `HostingWindowController` was working fine even though `viewDidLoad` was never called.