### PR TITLE
Fix full screen alert background

### DIFF
--- a/Calendr.xcodeproj/project.pbxproj
+++ b/Calendr.xcodeproj/project.pbxproj
@@ -793,7 +793,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 1.21.2;
+				MARKETING_VERSION = 1.21.3;
 				PRODUCT_BUNDLE_IDENTIFIER = br.paker.Calendr;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Calendr/ObjC/Calendr-Bridging-Header.h";
@@ -829,7 +829,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 1.21.2;
+				MARKETING_VERSION = 1.21.3;
 				PRODUCT_BUNDLE_IDENTIFIER = br.paker.Calendr;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/Calendr/Events/EventFullscreen/EventFullScreenViewController.swift
+++ b/Calendr/Events/EventFullscreen/EventFullScreenViewController.swift
@@ -11,8 +11,6 @@ typealias EventFullScreenViewController = HostingViewModelController<EventFullSc
 
 struct EventFullScreenView: ViewModelView {
 
-    @Environment(\.colorScheme) var colorScheme
-
     typealias ViewModel = EventFullScreenViewModel
 
     @State private var viewModel: ViewModel
@@ -22,19 +20,17 @@ struct EventFullScreenView: ViewModelView {
     }
 
     var body: some View {
-        let bgColor = colorScheme == .dark ? Color.black : Color.white
-        let shadowRadius = CGFloat(5)
         ZStack {
             VStack(spacing: 16) {
                 Text(viewModel.title)
-                    .font(.system(size: 40))
+                    .font(.system(size: 48))
                     .fontWeight(.medium)
-                    .shadow(color: bgColor, radius: shadowRadius)
+                    .foregroundStyle(.white)
 
                 Text(viewModel.duration)
                     .font(.system(size: 24))
                     .fontWeight(.regular)
-                    .shadow(color: bgColor, radius: shadowRadius)
+                    .foregroundStyle(.white)
 
                 Spacer(minLength: 100)
 
@@ -84,7 +80,8 @@ struct EventFullScreenView: ViewModelView {
         .onExitCommand(perform: viewModel.performClose)
         .onAppear(perform: viewModel.onAppear)
         .frame(maxWidth: .infinity, maxHeight: .infinity)
-        .background(.black.opacity(0.01))
+        .background(.ultraThickMaterial)
+        .colorScheme(.dark)
     }
 }
 

--- a/Calendr/Events/EventFullscreen/EventFullScreenWindow.swift
+++ b/Calendr/Events/EventFullscreen/EventFullScreenWindow.swift
@@ -25,8 +25,6 @@ class EventFullScreenWindow: NSWindow {
         backgroundColor = .clear
         hasShadow = false
         contentViewController = viewController
-
-        applyDesktopBlur(to: self, radius: 45)
     }
 
     convenience init(viewModel: EventFullScreenViewModel) {
@@ -41,26 +39,5 @@ class EventFullScreenWindow: NSWindow {
         NSApp.windows.filter(\.isModalPanel).forEach { $0.close() }
         setFrame(screen.frame, display: true, animate: false)
         makeKeyAndOrderFront(nil)
-    }
-}
-
-// MARK: - Hacky Window Blur
-
-// C-Declarations to link directly into the macOS WindowServer
-@_silgen_name("CGSMainConnectionID")
-private func CGSMainConnectionID() -> Int32
-
-@_silgen_name("CGSSetWindowBackgroundBlurRadius")
-private func CGSSetWindowBackgroundBlurRadius(_ cid: Int32, _ wid: Int32, _ radius: Int32) -> Int32
-
-private func applyDesktopBlur(to window: NSWindow, radius: Int) {
-    let connectionID = CGSMainConnectionID()
-    let windowID = Int32(window.windowNumber)
-
-    let result = CGSSetWindowBackgroundBlurRadius(connectionID, windowID, Int32(radius))
-
-    if result != 0 {
-        print("Failed to apply window background blur. Error code: \(result)")
-        window.backgroundColor = .windowBackgroundColor.withAlphaComponent(0.8)
     }
 }


### PR DESCRIPTION
Fix #645

- Replace hacky background blur with macOS native thick material.
- Stick with dark mode and make texts pure white for more contrast.
- Increase title font size a little.