### PR TITLE
Allow sudden termination

### DIFF
--- a/Calendr/Main/AppDelegate.swift
+++ b/Calendr/Main/AppDelegate.swift
@@ -107,15 +107,4 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         skipReopen.onNext(false)
         return false
     }
-
-    private let activity = {
-        ProcessInfo.processInfo.beginActivity(
-            options: [
-                .userInitiatedAllowingIdleSystemSleep,
-                .automaticTerminationDisabled,
-                .suddenTerminationDisabled
-            ],
-            reason: "Stop killing my app!"
-        )
-    }()
 }


### PR DESCRIPTION
There's no clean-up to be made, so we can allow sudden termination.

Note that this is different from "automatic termination", which allows idle apps be killed, but even this feature is off by default.

Neither of these options helped in any way to prevent the `CacheDelete` purge that was killing the app before.
That's a universally unresolved problem and cannot be prevented.

We now have a launch agent for the case where the app gets brutally murdered in the background.