### PR TITLE
Batch skip operations to avoid flicker

### DIFF
--- a/Calendr.xcodeproj/project.pbxproj
+++ b/Calendr.xcodeproj/project.pbxproj
@@ -793,7 +793,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 1.21.4;
+				MARKETING_VERSION = 1.21.5;
 				PRODUCT_BUNDLE_IDENTIFIER = br.paker.Calendr;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Calendr/ObjC/Calendr-Bridging-Header.h";
@@ -829,7 +829,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 1.21.4;
+				MARKETING_VERSION = 1.21.5;
 				PRODUCT_BUNDLE_IDENTIFIER = br.paker.Calendr;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/Calendr/Extensions/Rx+Helpers.swift
+++ b/Calendr/Extensions/Rx+Helpers.swift
@@ -50,6 +50,29 @@ extension ObservableType {
         _ = bind { value = $0 }
         return value
     }
+
+    /// Groups elements into an array when the stream goes quiet for a specified duration.
+    /// Unlike standard `.buffer`, this does not run a continuous timer and will never emit empty arrays.
+    ///
+    /// - Parameters:
+    ///   - timeSpan: The duration the stream must be quiet before emitting the accumulated batch.
+    ///   - scheduler: The scheduler to run the debounce timer on.
+    /// - Returns: An observable sequence of accumulated element arrays.
+    func batch(timeSpan: RxTimeInterval, scheduler: SchedulerType) -> Observable<[Element]> {
+        .deferred {
+            var memoryBuffer = [Element]()
+            
+            return observe(on: scheduler)
+                .map { newElement in
+                    memoryBuffer.append(newElement)
+                    return memoryBuffer
+                }
+                .debounce(timeSpan, scheduler: scheduler)
+                .do(onNext: { _ in
+                    memoryBuffer = []
+                })
+        }
+    }
 }
 
 extension PublishSubject {

--- a/Calendr/Extensions/Rx+Helpers.swift
+++ b/Calendr/Extensions/Rx+Helpers.swift
@@ -56,7 +56,7 @@ extension ObservableType {
     ///
     /// - Parameters:
     ///   - timeSpan: The duration the stream must be quiet before emitting the accumulated batch.
-    ///   - scheduler: The scheduler to run the debounce timer on.
+    ///   - scheduler: The scheduler to run the debounce timer on. It must be a serial scheduler.
     /// - Returns: An observable sequence of accumulated element arrays.
     func batch(timeSpan: RxTimeInterval, scheduler: SchedulerType) -> Observable<[Element]> {
         .deferred {

--- a/Calendr/MenuBar/NextEventViewModel.swift
+++ b/Calendr/MenuBar/NextEventViewModel.swift
@@ -364,9 +364,10 @@ class NextEventViewModel {
             .compactMap {
                 if case .event(let event, .skip) = $0 { event } else { nil }
             }
+            .buffer(timeSpan: .milliseconds(1), count: Int.max, scheduler: scheduler)
             .withLatestFrom(skippedEvents) { ($0, $1) }
             .map { event, skipped in
-                let result = skipped + [Skipped(event)]
+                let result = skipped + event.map(Skipped.init)
                 return result.suffix(MAX_SKIPPED)
             }
             .bind(to: skippedEvents)

--- a/Calendr/MenuBar/NextEventViewModel.swift
+++ b/Calendr/MenuBar/NextEventViewModel.swift
@@ -364,7 +364,7 @@ class NextEventViewModel {
             .compactMap {
                 if case .event(let event, .skip) = $0 { event } else { nil }
             }
-            .buffer(timeSpan: .milliseconds(1), count: Int.max, scheduler: scheduler)
+            .batch(timeSpan: .milliseconds(1), scheduler: scheduler)
             .withLatestFrom(skippedEvents) { ($0, $1) }
             .map { event, skipped in
                 let result = skipped + event.map(Skipped.init)

--- a/CalendrTests/NextEventViewModelFullScreenTests.swift
+++ b/CalendrTests/NextEventViewModelFullScreenTests.swift
@@ -419,7 +419,9 @@ class NextEventViewModelFullScreenTests: XCTestCase {
 
         fullScreen?.onAppear()
         scheduler.advance(.seconds(2))
+
         fullScreen?.skip()
+        scheduler.advance(.milliseconds(1))
 
         XCTAssertNil(fullScreen)
         XCTAssertNil(viewModel.title.lastValue())

--- a/CalendrTests/NextEventViewModelTests.swift
+++ b/CalendrTests/NextEventViewModelTests.swift
@@ -929,10 +929,14 @@ class NextEventViewModelTests: XCTestCase {
 
         try XCTUnwrap(viewModel.makeContextMenuViewModel() as? EventOptionsViewModel).triggerAction(.skip)
 
+        scheduler.advance(.milliseconds(1))
+
         XCTAssertEqual(title, "Event 2")
         XCTAssertEqual(hasEvent, true)
 
         try XCTUnwrap(viewModel.makeContextMenuViewModel() as? EventOptionsViewModel).triggerAction(.skip)
+
+        scheduler.advance(.milliseconds(1))
 
         XCTAssertEqual(hasEvent, false)
     }
@@ -963,10 +967,14 @@ class NextEventViewModelTests: XCTestCase {
 
         try XCTUnwrap(viewModel.makeDetailsViewModel()).skipTapped.onNext(())
 
+        scheduler.advance(.milliseconds(1))
+
         XCTAssertEqual(title, "Event 2")
         XCTAssertEqual(hasEvent, true)
 
         try XCTUnwrap(viewModel.makeDetailsViewModel()).skipTapped.onNext(())
+
+        scheduler.advance(.milliseconds(1))
 
         XCTAssertEqual(hasEvent, false)
     }

--- a/CalendrTests/Rx+HelpersTests.swift
+++ b/CalendrTests/Rx+HelpersTests.swift
@@ -1,0 +1,50 @@
+//
+//  Rx+HelpersTests.swift
+//  Calendr
+//
+//  Created by Paker on 07/06/2026.
+//
+
+import XCTest
+import RxSwift
+@testable import Calendr
+
+class RxHelpersTests: XCTestCase {
+
+    let scheduler = HistoricalScheduler()
+
+    func testBatch_shouldNotProduceEmptyResults() {
+
+        let batchExpectation = expectation(description: "Batch")
+
+        let subject = PublishSubject<Int>()
+
+        var result: [Int]?
+
+        _ = subject.batch(timeSpan: .milliseconds(1), scheduler: scheduler).bind {
+            XCTAssertNotNil($0)
+            result = $0
+            batchExpectation.fulfill()
+        }
+
+        scheduler.advance(.milliseconds(1))
+
+        XCTAssertNil(result)
+
+        subject.onNext(1)
+        subject.onNext(2)
+        subject.onNext(3)
+
+        scheduler.advance(.milliseconds(1))
+
+        XCTAssertEqual(result, [1,2,3])
+
+        result = nil
+
+        scheduler.advance(.milliseconds(1))
+
+        XCTAssertNil(result)
+
+        wait(for: [batchExpectation], timeout: 0.1)
+    }
+}


### PR DESCRIPTION
This avoids intermediate updates when skipping grouped events.