### PR TITLE
Fix missing some modules on SPM indexing

### DIFF
--- a/.sourcekit-lsp/config.json
+++ b/.sourcekit-lsp/config.json
@@ -1,0 +1,3 @@
+{
+    "backgroundPreparationMode": "build"
+}

--- a/Calendr/Main/AppDelegate.swift
+++ b/Calendr/Main/AppDelegate.swift
@@ -7,7 +7,6 @@
 
 import Cocoa
 import RxSwift
-import Sentry
 
 class AppDelegate: NSObject, NSApplicationDelegate {
 


### PR DESCRIPTION
Update sourcekit-lsp to use a full build for background indexing.

Removed unnecessary Sentry import from AppDelegate (unrelated)

## Culprit
The Sentry SDK is distributed as a pre-compiled xcframework (binary target) via SPM. When `swift build --experimental-prepare-for-indexing` runs, SPM skips copying the binary framework into the build products directory, so the compiler can't find the Sentry module.

https://github.com/getsentry/sentry-cocoa/issues/7472