### PR TITLE
SPM ad-hoc signing + sandbox + hardened runtime

### DIFF
--- a/Calendr/Main/ResourceBundleAccessor.swift
+++ b/Calendr/Main/ResourceBundleAccessor.swift
@@ -1,0 +1,46 @@
+import Foundation
+
+#if SWIFT_MODULE_RESOURCE_BUNDLE_AVAILABLE
+
+extension Bundle {
+    /// This fixes the auto-generated `resource_bundle_accessor.swift`,
+    /// which tries to access `Bundle.module` from root.
+    ///
+    /// Sandboxed apps need bundles to be in `Contents/Resources`.
+    ///
+    /// Call this at the absolute top of your launch sequence (e.g., in `main.swift` or app init).
+    public static func swizzleResourceBundleAccessor() {
+        let bundleClass: AnyClass = Bundle.self
+
+        let originalSelector = #selector(Bundle.init(path:))
+        let swizzledSelector = #selector(Bundle.init(sandbox_path:))
+
+        guard
+            let originalMethod = class_getInstanceMethod(bundleClass, originalSelector),
+            let swizzledMethod = class_getInstanceMethod(bundleClass, swizzledSelector)
+        else {
+            return
+        }
+
+        method_exchangeImplementations(originalMethod, swizzledMethod)
+    }
+
+    @objc private convenience init?(sandbox_path path: String) {
+
+        // Check if the unmodifiable 3rd-party code looked inside Contents/MacOS
+        guard path.hasPrefix(Bundle.main.bundlePath), path.hasSuffix(".bundle") else {
+            // Due to swizzling, calling 'init(sandbox_path:)' calls the original 'init(path:)'
+            self.init(sandbox_path: path)
+            return
+        }
+
+        // Transform the path to point safely into Contents/Resources/
+        let correctedPath = path.replacing(
+            Bundle.main.bundlePath, with: Bundle.main.resourcePath!)
+
+        // Try initializing with the sandbox-approved path
+        self.init(sandbox_path: correctedPath)
+    }
+}
+
+#endif

--- a/Calendr/Main/main.swift
+++ b/Calendr/Main/main.swift
@@ -7,6 +7,10 @@
 
 import Cocoa
 
+#if SWIFT_MODULE_RESOURCE_BUNDLE_AVAILABLE
+Bundle.swizzleResourceBundleAccessor()
+#endif
+
 private let delegate = AppDelegate()
 NSApplication.shared.delegate = delegate
 NSApplication.shared.run()

--- a/assemble.entitlements
+++ b/assemble.entitlements
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.app-sandbox</key>
+	<true/>
+	<key>com.apple.security.automation.apple-events</key>
+	<true/>
+	<key>com.apple.security.files.user-selected.executable</key>
+	<true/>
+	<key>com.apple.security.files.user-selected.read-write</key>
+	<true/>
+	<key>com.apple.security.network.client</key>
+	<true/>
+	<key>com.apple.security.personal-information.calendars</key>
+	<true/>
+	<key>com.apple.security.temporary-exception.apple-events</key>
+	<array>
+		<string>com.apple.ical</string>
+	</array>
+</dict>
+</plist>

--- a/assemble.sh
+++ b/assemble.sh
@@ -119,4 +119,40 @@ else
     echo -e "⚠️  resources/AppIcon.icns not found — app will have no icon.\n"
 fi
 
+prepare_entitlements() {
+    local dest="$1"
+    cp "assemble.entitlements" "$dest"
+
+    if [[ "$MODE" == "debug" ]]; then
+        plutil -replace 'com\.apple\.security\.get-task-allow' -bool true "$dest"
+    fi
+}
+
+sign_framework() {
+    local framework="$1"
+    local name="${framework%.framework}"
+    name="${name##*/}"
+    local binary="$framework/Versions/Current/$name"
+
+    if [[ -f "$binary" ]]; then
+        codesign --force --sign "$SIGN_IDENTITY" --options runtime "$binary"
+    fi
+    codesign --force --sign "$SIGN_IDENTITY" --options runtime "$framework"
+}
+
+# Ad-hoc signing keeps local assemble builds launchable without Gatekeeper
+# developer verification (Apple Development certs trigger that check).
+SIGN_IDENTITY="-"
+ENTITLEMENTS=$(mktemp)
+prepare_entitlements "$ENTITLEMENTS"
+
+echo -e "\n🔏 Signing with ad-hoc identity (sandbox entitlements)\n"
+
+while IFS= read -r -d '' framework; do
+    sign_framework "$framework"
+done < <(find "$CONTENTS/Frameworks" -name "*.framework" -print0 2>/dev/null)
+
+# Sign the app bundle with entitlements and hardened runtime
+codesign --force --sign "$SIGN_IDENTITY" --entitlements "$ENTITLEMENTS" --options runtime "$APP_BUNDLE"
+
 echo "✅ $APP_BUNDLE assembled successfully!"

--- a/assemble.sh
+++ b/assemble.sh
@@ -124,7 +124,7 @@ prepare_entitlements() {
     cp "assemble.entitlements" "$dest"
 
     if [[ "$MODE" == "debug" ]]; then
-        plutil -replace 'com\.apple\.security\.get-task-allow' -bool true "$dest"
+        plutil -insert 'com\.apple\.security\.get-task-allow' -bool true "$dest"
     fi
 }
 


### PR DESCRIPTION
This allows us to test SPM builds with the same restrictions as the Xcode build.
It also shares the same app container and preferences from the real app.

**Sandboxing and Permissions**

* Updated `assemble.sh` to use the entitlements during code signing, ensuring the app and its frameworks are signed with the correct permissions and hardened runtime options.

**Resource Bundle Loading Fix**

* Introduced `Bundle.swizzleResourceBundleAccessor()` in `ResourceBundleAccessor.swift` to patch resource bundle loading, ensuring compatibility with sandboxed app layouts by redirecting bundle lookups to `Contents/Resources`.