### PR TITLE
Smart date/time editing on event creation

### DIFF
--- a/Calendr/Editors/EventEditorViewModel.swift
+++ b/Calendr/Editors/EventEditorViewModel.swift
@@ -16,16 +16,14 @@ class EventEditorViewModel: HostingWindowControllerDelegate {
     var startDate: Date {
         didSet {
             guard !isSyncingDates, startDate != oldValue else { return }
+            isSyncingDates = true
+            defer { isSyncingDates = false }
 
             if isAllDay {
                 guard calendar.isDate(endDate, lessThan: startDate, granularity: .day) else { return }
-                isSyncingDates = true
                 endDate = startDate
-                isSyncingDates = false
             } else {
-                isSyncingDates = true
                 endDate = startDate.addingTimeInterval(eventDuration)
-                isSyncingDates = false
             }
         }
     }

--- a/Calendr/Editors/EventEditorViewModel.swift
+++ b/Calendr/Editors/EventEditorViewModel.swift
@@ -13,8 +13,29 @@ import RxSwift
 class EventEditorViewModel: HostingWindowControllerDelegate {
 
     var title = ""
-    var startDate: Date
-    var endDate: Date
+    var startDate: Date {
+        didSet {
+            guard !isSyncingDates, startDate != oldValue else { return }
+
+            if isAllDay {
+                guard calendar.isDate(endDate, lessThan: startDate, granularity: .day) else { return }
+                isSyncingDates = true
+                endDate = startDate
+                isSyncingDates = false
+            } else {
+                isSyncingDates = true
+                endDate = startDate.addingTimeInterval(eventDuration)
+                isSyncingDates = false
+            }
+        }
+    }
+    var endDate: Date {
+        didSet {
+            guard !isSyncingDates, endDate != oldValue, !isAllDay else { return }
+            guard endDate > startDate else { return }
+            eventDuration = endDate.timeIntervalSince(startDate)
+        }
+    }
     var isAllDay = false {
         didSet {
             guard isAllDay != oldValue else { return }
@@ -59,6 +80,9 @@ class EventEditorViewModel: HostingWindowControllerDelegate {
 
     private let disposeBag = DisposeBag()
 
+    private var eventDuration: TimeInterval = 3600
+    private var isSyncingDates = false
+
     private var calendar: Calendar { dateProvider.calendar.with(timeZone: selectedTimeZone) }
 
     var selectedTimeZone: TimeZone {
@@ -67,8 +91,11 @@ class EventEditorViewModel: HostingWindowControllerDelegate {
 
     init(startDate: DueDate, dateProvider: DateProviding, calendarService: CalendarServiceProviding) {
         self.dateProvider = dateProvider
-        self.startDate = startDate.date
-        self.endDate = dateProvider.calendar.date(byAdding: .hour, value: 1, to: startDate.date)!
+        let roundedStart = roundUpToNextHour(startDate.date, using: dateProvider)
+        let defaultDuration: TimeInterval = 3600
+        self.startDate = roundedStart
+        self.eventDuration = defaultDuration
+        self.endDate = roundedStart.addingTimeInterval(defaultDuration)
         self.calendarService = calendarService
         self.selectedTimeZoneIdentifier = dateProvider.calendar.timeZone.identifier
 
@@ -170,7 +197,9 @@ class EventEditorViewModel: HostingWindowControllerDelegate {
                 endDate = startDate
             }
         } else if endDate <= startDate {
-            endDate = calendar.date(byAdding: .hour, value: 1, to: startDate)!
+            isSyncingDates = true
+            endDate = startDate.addingTimeInterval(eventDuration)
+            isSyncingDates = false
         }
     }
 
@@ -198,4 +227,11 @@ class EventEditorViewModel: HostingWindowControllerDelegate {
             selectedCalendarId = first.id
         }
     }
+}
+
+private func roundUpToNextHour(_ date: Date, using dateProvider: DateProviding) -> Date {
+    let calendar = dateProvider.calendar
+    guard let interval = calendar.dateInterval(of: .hour, for: date) else { return date }
+    if date == interval.start { return date }
+    return calendar.date(byAdding: .hour, value: 1, to: interval.start)!
 }

--- a/Calendr/Editors/EventEditorViewModel.swift
+++ b/Calendr/Editors/EventEditorViewModel.swift
@@ -172,6 +172,8 @@ class EventEditorViewModel: HostingWindowControllerDelegate {
     private func preserveWallClockTime(from oldTimeZone: TimeZone) {
         let newTimeZone = selectedTimeZone
         guard oldTimeZone != newTimeZone else { return }
+        isSyncingDates = true
+        defer { isSyncingDates = false }
 
         let oldCalendar = dateProvider.calendar.with(timeZone: oldTimeZone)
         let newCalendar = dateProvider.calendar.with(timeZone: newTimeZone)
@@ -181,13 +183,16 @@ class EventEditorViewModel: HostingWindowControllerDelegate {
             : [.year, .month, .day, .hour, .minute, .second]
 
         let startComponents = oldCalendar.dateComponents(components, from: startDate)
-        startDate = newCalendar.date(from: startComponents) ?? startDate
-
         let endComponents = oldCalendar.dateComponents(components, from: endDate)
+
+        startDate = newCalendar.date(from: startComponents) ?? startDate
         endDate = newCalendar.date(from: endComponents) ?? endDate
     }
 
     private func adjustDatesForAllDayChange() {
+        isSyncingDates = true
+        defer { isSyncingDates = false }
+
         if isAllDay {
             startDate = calendar.startOfDay(for: startDate)
             endDate = calendar.startOfDay(for: endDate)
@@ -195,9 +200,7 @@ class EventEditorViewModel: HostingWindowControllerDelegate {
                 endDate = startDate
             }
         } else if endDate <= startDate {
-            isSyncingDates = true
             endDate = startDate.addingTimeInterval(eventDuration)
-            isSyncingDates = false
         }
     }
 

--- a/CalendrTests/EventEditorViewModelTests.swift
+++ b/CalendrTests/EventEditorViewModelTests.swift
@@ -254,6 +254,7 @@ class EventEditorViewModelTests: XCTestCase {
         viewModel.selectedTimeZoneIdentifier = "UTC"
 
         XCTAssertEqual(viewModel.startDate, .make(year: 2025, month: 10, day: 25, hour: 15, minute: 0, timeZone: .utc))
+        XCTAssertEqual(viewModel.endDate, .make(year: 2025, month: 10, day: 25, hour: 16, minute: 0, timeZone: .utc))
     }
 
     func testViewModel_init_roundsStartUpToNextHour() {

--- a/CalendrTests/EventEditorViewModelTests.swift
+++ b/CalendrTests/EventEditorViewModelTests.swift
@@ -16,7 +16,7 @@ class EventEditorViewModelTests: XCTestCase {
     override func setUp() {
         super.setUp()
         dateProvider = MockDateProvider()
-        dateProvider.now = Date.make(year: 2025, month: 10, day: 25, hour: 10, minute: 30)
+        dateProvider.now = .make(year: 2025, month: 10, day: 25, hour: 10, minute: 30)
     }
 
     func testViewModel_initialState() {
@@ -30,11 +30,9 @@ class EventEditorViewModelTests: XCTestCase {
             calendarService: calendarService
         )
 
-        let expectedEnd = dateProvider.calendar.date(byAdding: .hour, value: 1, to: start)!
-
         XCTAssertEqual(viewModel.title, "")
-        XCTAssertEqual(viewModel.startDate, start)
-        XCTAssertEqual(viewModel.endDate, expectedEnd)
+        XCTAssertEqual(viewModel.startDate, .make(year: 2025, month: 10, day: 25, hour: 11, minute: 0))
+        XCTAssertEqual(viewModel.endDate, .make(year: 2025, month: 10, day: 25, hour: 12, minute: 0))
         XCTAssertFalse(viewModel.isAllDay)
         XCTAssertEqual(viewModel.location, "")
         XCTAssertEqual(viewModel.url, "")
@@ -83,10 +81,14 @@ class EventEditorViewModelTests: XCTestCase {
         let calendarService = MockCalendarServiceProvider()
         calendarService.m_calendars = [.make(id: "cal-1")]
 
-        let viewModel = EventEditorViewModel(dateProvider: dateProvider, calendarService: calendarService)
+        let viewModel = EventEditorViewModel(
+            startDate: .make(year: 2025, month: 10, day: 25, hour: 10, minute: 30),
+            dateProvider: dateProvider,
+            calendarService: calendarService
+        )
 
         viewModel.title = "Meeting"
-        viewModel.endDate = dateProvider.calendar.date(byAdding: .hour, value: 1, to: viewModel.startDate)!
+        viewModel.endDate = .make(year: 2025, month: 10, day: 25, hour: 13, minute: 0)
 
         XCTAssertTrue(viewModel.hasValidDateRange)
         XCTAssertTrue(viewModel.hasValidInput)
@@ -101,8 +103,8 @@ class EventEditorViewModelTests: XCTestCase {
 
         viewModel.title = "Holiday"
         viewModel.isAllDay = true
-        viewModel.startDate = Date.make(year: 2025, month: 10, day: 25, at: .start)
-        viewModel.endDate = Date.make(year: 2025, month: 10, day: 25, at: .start)
+        viewModel.startDate = .make(year: 2025, month: 10, day: 25, at: .start)
+        viewModel.endDate = .make(year: 2025, month: 10, day: 25, at: .start)
 
         XCTAssertTrue(viewModel.hasValidDateRange)
         XCTAssertTrue(viewModel.hasValidInput)
@@ -117,8 +119,8 @@ class EventEditorViewModelTests: XCTestCase {
 
         viewModel.title = "Holiday"
         viewModel.isAllDay = true
-        viewModel.startDate = Date.make(year: 2025, month: 10, day: 25, at: .start)
-        viewModel.endDate = Date.make(year: 2025, month: 10, day: 24, at: .start)
+        viewModel.startDate = .make(year: 2025, month: 10, day: 25, at: .start)
+        viewModel.endDate = .make(year: 2025, month: 10, day: 24, at: .start)
 
         XCTAssertFalse(viewModel.hasValidDateRange)
         XCTAssertFalse(viewModel.hasValidInput)
@@ -127,30 +129,29 @@ class EventEditorViewModelTests: XCTestCase {
     func testViewModel_isAllDay_toggleOn_stripsTimeAndFixesEnd() {
 
         let viewModel = EventEditorViewModel(
-            startDate: Date.make(year: 2025, month: 10, day: 25, hour: 14, minute: 30),
+            startDate: .make(year: 2025, month: 10, day: 25, hour: 14, minute: 30),
             dateProvider: dateProvider
         )
 
-        viewModel.endDate = Date.make(year: 2025, month: 10, day: 24, hour: 16)
+        viewModel.endDate = .make(year: 2025, month: 10, day: 24, hour: 16)
 
         viewModel.isAllDay = true
 
-        XCTAssertEqual(viewModel.startDate, Date.make(year: 2025, month: 10, day: 25, at: .start))
-        XCTAssertEqual(viewModel.endDate, Date.make(year: 2025, month: 10, day: 25, at: .start))
+        XCTAssertEqual(viewModel.startDate, .make(year: 2025, month: 10, day: 25, at: .start))
+        XCTAssertEqual(viewModel.endDate, .make(year: 2025, month: 10, day: 25, at: .start))
     }
 
     func testViewModel_isAllDay_toggleOff_setsEndOneHourAfterStartWhenNeeded() {
 
         let viewModel = EventEditorViewModel(
-            startDate: Date.make(year: 2025, month: 10, day: 25, hour: 14),
+            startDate: .make(year: 2025, month: 10, day: 25, hour: 14),
             dateProvider: dateProvider
         )
 
         viewModel.isAllDay = true
         viewModel.isAllDay = false
 
-        let expectedEnd = dateProvider.calendar.date(byAdding: .hour, value: 1, to: viewModel.startDate)!
-        XCTAssertEqual(viewModel.endDate, expectedEnd)
+        XCTAssertEqual(viewModel.endDate, .make(year: 2025, month: 10, day: 25, hour: 1, minute: 0))
     }
 
     func testViewModel_saveEvent_withInvalidInput_shouldNotCallService() {
@@ -177,8 +178,8 @@ class EventEditorViewModelTests: XCTestCase {
         let calendarService = MockCalendarServiceProvider()
         calendarService.m_calendars = [.make(id: "cal-1")]
 
-        let start = dateProvider.now
-        let end = dateProvider.calendar.date(byAdding: .hour, value: 2, to: start)!
+        let start: Date = .make(year: 2025, month: 10, day: 25, hour: 11, minute: 0)
+        let end: Date = .make(year: 2025, month: 10, day: 25, hour: 12, minute: 30)
 
         let viewModel = EventEditorViewModel(
             startDate: .init(date: start),
@@ -241,20 +242,95 @@ class EventEditorViewModelTests: XCTestCase {
         let oldTimeZone = TimeZone(secondsFromGMT: 3 * 3600)!
         dateProvider.m_calendar = Calendar.gregorian.with(timeZone: oldTimeZone)
 
-        let start = Date.make(year: 2025, month: 10, day: 25, hour: 14, minute: 30, timeZone: oldTimeZone)
+        let start: Date = .make(year: 2025, month: 10, day: 25, hour: 14, minute: 30, timeZone: oldTimeZone)
 
         let viewModel = EventEditorViewModel(
             startDate: start,
             dateProvider: dateProvider
         )
 
+        XCTAssertEqual(viewModel.startDate, .make(year: 2025, month: 10, day: 25, hour: 15, minute: 0, timeZone: oldTimeZone))
+
         viewModel.selectedTimeZoneIdentifier = "UTC"
 
-        let utcCalendar = Calendar.gregorian.with(timeZone: TimeZone(identifier: "UTC")!)
-        let components = utcCalendar.dateComponents([.hour, .minute], from: viewModel.startDate)
+        XCTAssertEqual(viewModel.startDate, .make(year: 2025, month: 10, day: 25, hour: 15, minute: 0, timeZone: .utc))
+    }
 
-        XCTAssertEqual(components.hour, 14)
-        XCTAssertEqual(components.minute, 30)
+    func testViewModel_init_roundsStartUpToNextHour() {
+
+        let onTheHour: Date = .make(year: 2025, month: 10, day: 25, hour: 10, minute: 0)
+        let withMinutes: Date = .make(year: 2025, month: 10, day: 25, hour: 10, minute: 30)
+
+        let onTheHourViewModel = EventEditorViewModel(
+            startDate: onTheHour,
+            dateProvider: dateProvider
+        )
+        let withMinutesViewModel = EventEditorViewModel(
+            startDate: withMinutes,
+            dateProvider: dateProvider
+        )
+
+        XCTAssertEqual(onTheHourViewModel.startDate, onTheHour)
+        XCTAssertEqual(withMinutesViewModel.startDate, .make(year: 2025, month: 10, day: 25, hour: 11, minute: 0))
+    }
+
+    func testViewModel_changingEndDate_tracksDuration() {
+
+        let viewModel = EventEditorViewModel(
+            startDate: .make(year: 2025, month: 10, day: 25, hour: 10),
+            dateProvider: dateProvider
+        )
+
+        viewModel.endDate = .make(year: 2025, month: 10, day: 25, hour: 12, minute: 0)
+
+        viewModel.startDate = .make(year: 2025, month: 10, day: 25, hour: 13, minute: 0)
+
+        XCTAssertEqual(viewModel.endDate, .make(year: 2025, month: 10, day: 25, hour: 15, minute: 0))
+    }
+
+    func testViewModel_changingEndDate_invalid_doesNotUpdateDuration() {
+
+        let viewModel = EventEditorViewModel(
+            startDate: .make(year: 2025, month: 10, day: 25, hour: 10),
+            dateProvider: dateProvider
+        )
+
+        viewModel.endDate = .make(year: 2025, month: 10, day: 25, hour: 12, minute: 0)
+        viewModel.endDate = viewModel.startDate
+
+        viewModel.startDate = .make(year: 2025, month: 10, day: 25, hour: 13, minute: 0)
+
+        XCTAssertEqual(viewModel.endDate, .make(year: 2025, month: 10, day: 25, hour: 15, minute: 0))
+    }
+
+    func testViewModel_isAllDay_changingStartDate_fixesInvalidEnd() {
+
+        let viewModel = EventEditorViewModel(
+            startDate: .make(year: 2025, month: 10, day: 25, hour: 10),
+            dateProvider: dateProvider
+        )
+
+        viewModel.isAllDay = true
+        viewModel.startDate = .make(year: 2025, month: 10, day: 26, at: .start)
+
+        XCTAssertEqual(viewModel.startDate, .make(year: 2025, month: 10, day: 26, at: .start))
+        XCTAssertEqual(viewModel.endDate, .make(year: 2025, month: 10, day: 26, at: .start))
+    }
+
+    func testViewModel_isAllDay_changingStartDate_keepsValidEnd() {
+
+        let viewModel = EventEditorViewModel(
+            startDate: .make(year: 2025, month: 10, day: 25, hour: 10),
+            dateProvider: dateProvider
+        )
+
+        viewModel.isAllDay = true
+
+        XCTAssertEqual(viewModel.endDate, .make(year: 2025, month: 10, day: 25, at: .start))
+
+        viewModel.startDate = .make(year: 2025, month: 10, day: 26, at: .start)
+
+        XCTAssertEqual(viewModel.endDate, .make(year: 2025, month: 10, day: 26, at: .start))
     }
 
     func testViewModel_initialState_selectedAlertIsNone() {


### PR DESCRIPTION
Close #687 

### Date time events
- Round up the start time to the next hour on init.
- Track the time difference between start and end, when the user changes the end time (if valid).
- Reapply the time difference when the user changes the start time.

### All-day events
- Move end date to a valid one (greater or equal start) when user changes the start date.