### PR TITLE
Update Japanese translations

### DIFF
--- a/Calendr/Assets/ja.lproj/Localizable.strings
+++ b/Calendr/Assets/ja.lproj/Localizable.strings
@@ -109,7 +109,7 @@
 "formatter.date.relative.ago" = "%@前";
 "formatter.date.relative.left" = "残り%@";
 
-"formatter.events.plural" = "%@件のイベント";
+"formatter.events.plural" = "%@件の予定";
 "formatter.reminders.plural" = "%@件のリマインダー";
 
 "reminder.status.overdue" = "期限超過";
@@ -123,7 +123,7 @@
 "editor.confirm.continue" = "作成を続ける";
 "editor.confirm.discard" = "変更を破棄";
 
-"event.editor.headline" = "新規イベント";
+"event.editor.headline" = "新規予定";
 "event.editor.start" = "開始";
 "event.editor.end" = "終了";
 "event.editor.time_zone" = "タイムゾーン";
@@ -153,17 +153,17 @@
 
 "event.all_day" = "終日";
 
-"event.status.accepted" = "参加";
+"event.status.accepted" = "承諾";
 "event.status.maybe" = "仮承諾";
 "event.status.declined" = "辞退";
 "event.status.pending" = "未返信";
 
 "event.action.open" = "開く";
-"event.action.join" = "参加";
+"event.action.join" = "参加する";
 "event.action.skip" = "スキップ";
-"event.action.accept" = "参加";
+"event.action.accept" = "承諾する";
 "event.action.maybe" = "仮承諾";
-"event.action.decline" = "辞退";
+"event.action.decline" = "辞退する";
 
 "event_list.summary.agenda" = "今日";
 

--- a/Calendr/Assets/ja.lproj/Localizable.strings
+++ b/Calendr/Assets/ja.lproj/Localizable.strings
@@ -14,7 +14,7 @@
 "access_required.cancel" = "キャンセル";
 
 "auto_update.check_for_updates" = "更新を確認";
-//"auto_update.check_automatically" = "Automatically check for updates";
+"auto_update.check_automatically" = "自動的に更新を確認";
 "auto_update.fetching_releases" = "更新を確認中";
 "auto_update.new_version" = "バージョン %@ が利用可能です";
 "auto_update.updated_to" = "バージョン %@ に更新されました";
@@ -39,8 +39,8 @@
 
 "settings.menu_bar" = "メニューバー";
 "settings.menu_bar.auto_launch" = "ログイン時に起動";
-//"settings.menu_bar.launch_agent" = "Relaunch automatically";
-//"settings.menu_bar.launch_agent_tooltip" = "Relaunch the app in case macOS decides to kill it due to low memory or disk space.";
+"settings.menu_bar.launch_agent" = "自動的に再起動";
+"settings.menu_bar.launch_agent_tooltip" = "メモリ不足やディスク容量不足を理由にmacOSがアプリを強制終了した場合、アプリを再起動します。";
 "settings.menu_bar.show_icon" = "アイコンを表示";
 "settings.menu_bar.show_date" = "日付を表示";
 "settings.menu_bar.show_background" = "不透明な背景";
@@ -52,7 +52,7 @@
 "settings.next_event.grab_attention" = "予定が近づいたら";
 "settings.next_event.grab_attention.flashing" = "点滅させる";
 "settings.next_event.grab_attention.sound" = "音を鳴らす";
-//"settings.next_event.show_full_screen_alert" = "Show full screen alert";
+"settings.next_event.show_full_screen_alert" = "フルスクリーンの通知を表示";
 "settings.next_event.detect_notch" = "ノッチがある場合に短くする";
 
 "settings.calendar" = "カレンダー";
@@ -75,7 +75,7 @@
 "settings.events" = "予定";
 "settings.events.show_map" = "地図と天気を表示";
 "settings.events.show_overdue_reminders" = "期限が過ぎたリマインダーを表示";
-//"settings.events.show_all_day_events" = "Show all-day events";
+"settings.events.show_all_day_events" = "終日の予定を表示";
 "settings.events.show_all_day_details" = "終日の予定の詳細を表示";
 "settings.events.show_finished_events" = "終了した予定を表示";
 "settings.events.show_recurrence_indicator" = "繰り返しの予定にマークを表示";
@@ -109,8 +109,8 @@
 "formatter.date.relative.ago" = "%@前";
 "formatter.date.relative.left" = "残り%@";
 
-//"formatter.events.plural" = "%@ events";
-//"formatter.reminders.plural" = "%@ reminders";
+"formatter.events.plural" = "%@件のイベント";
+"formatter.reminders.plural" = "%@件のリマインダー";
 
 "reminder.status.overdue" = "期限超過";
 
@@ -123,25 +123,25 @@
 "editor.confirm.continue" = "作成を続ける";
 "editor.confirm.discard" = "変更を破棄";
 
-//"event.editor.headline" = "New Event";
-//"event.editor.start" = "Start";
-//"event.editor.end" = "End";
-//"event.editor.time_zone" = "Time Zone";
-//"event.editor.location" = "Location";
-//"event.editor.url" = "URL";
-//"event.editor.notes" = "Notes";
+"event.editor.headline" = "新規イベント";
+"event.editor.start" = "開始";
+"event.editor.end" = "終了";
+"event.editor.time_zone" = "タイムゾーン";
+"event.editor.location" = "場所";
+"event.editor.url" = "URL";
+"event.editor.notes" = "メモ";
 
-//"event.editor.alert" = "Alert";
-//"event.editor.alert.none" = "None";
-//"event.editor.alert.at_time" = "At time of event";
-//"event.editor.alert.5_minutes_before" = "5 minutes before";
-//"event.editor.alert.10_minutes_before" = "10 minutes before";
-//"event.editor.alert.15_minutes_before" = "15 minutes before";
-//"event.editor.alert.30_minutes_before" = "30 minutes before";
-//"event.editor.alert.1_hour_before" = "1 hour before";
-//"event.editor.alert.2_hours_before" = "2 hours before";
-//"event.editor.alert.1_day_before" = "1 day before";
-//"event.editor.alert.2_days_before" = "2 days before";
+"event.editor.alert" = "通知";
+"event.editor.alert.none" = "なし";
+"event.editor.alert.at_time" = "予定の時刻";
+"event.editor.alert.5_minutes_before" = "5分前";
+"event.editor.alert.10_minutes_before" = "10分前";
+"event.editor.alert.15_minutes_before" = "15分前";
+"event.editor.alert.30_minutes_before" = "30分前";
+"event.editor.alert.1_hour_before" = "1時間前";
+"event.editor.alert.2_hours_before" = "2時間前";
+"event.editor.alert.1_day_before" = "1日前";
+"event.editor.alert.2_days_before" = "2日前";
 
 "reminder.editor.headline" = "新しいリマインダー";
 

--- a/Calendr/Assets/ja.lproj/Localizable.strings
+++ b/Calendr/Assets/ja.lproj/Localizable.strings
@@ -39,7 +39,7 @@
 
 "settings.menu_bar" = "メニューバー";
 "settings.menu_bar.auto_launch" = "ログイン時に起動";
-"settings.menu_bar.launch_agent" = "自動的に再起動";
+"settings.menu_bar.launch_agent" = "自動的にアプリを再起動";
 "settings.menu_bar.launch_agent_tooltip" = "メモリ不足やディスク容量不足を理由にmacOSがアプリを強制終了した場合、アプリを再起動します。";
 "settings.menu_bar.show_icon" = "アイコンを表示";
 "settings.menu_bar.show_date" = "日付を表示";

--- a/Calendr/Assets/ja.lproj/Localizable.strings
+++ b/Calendr/Assets/ja.lproj/Localizable.strings
@@ -143,27 +143,27 @@
 "event.editor.alert.1_day_before" = "1日前";
 "event.editor.alert.2_days_before" = "2日前";
 
-"reminder.editor.headline" = "新しいリマインダー";
+"reminder.editor.headline" = "新規リマインダー";
 
 "map_black_list.headline" = "以下の語が含まれる場合に地図を非表示にする";
-"map_black_list.new_item_text" = "新しい除外ワード";
+"map_black_list.new_item_text" = "新規除外ワード";
 
 "event.details.participant.organizer" = "主催者";
 "event.details.participant.me" = "自分";
 
-"event.all_day" = "全日";
+"event.all_day" = "終日";
 
-"event.status.accepted" = "出席";
+"event.status.accepted" = "参加";
 "event.status.maybe" = "仮承諾";
-"event.status.declined" = "欠席";
-"event.status.pending" = "未回答";
+"event.status.declined" = "辞退";
+"event.status.pending" = "未返信";
 
 "event.action.open" = "開く";
-"event.action.join" = "参加する";
+"event.action.join" = "参加";
 "event.action.skip" = "スキップ";
-"event.action.accept" = "出席";
+"event.action.accept" = "参加";
 "event.action.maybe" = "仮承諾";
-"event.action.decline" = "欠席";
+"event.action.decline" = "辞退";
 
 "event_list.summary.agenda" = "今日";
 

--- a/MISSING_TRANSLATIONS.md
+++ b/MISSING_TRANSLATIONS.md
@@ -6,7 +6,6 @@ Language|Count
 [Chinese - 中文 - (zh-Hant-TW)](Calendr/Assets/zh-Hant-TW.lproj/Localizable.strings)|45
 [Greek - Ελληνικά - (el)](Calendr/Assets/el.lproj/Localizable.strings)|48
 [Chinese - 中文 - (zh-Hans)](Calendr/Assets/zh-Hans.lproj/Localizable.strings)|26
-[Japanese - 日本語 - (ja)](Calendr/Assets/ja.lproj/Localizable.strings)|25
 [Albanian - shqip - (sq)](Calendr/Assets/sq.lproj/Localizable.strings)|48
 [Ukrainian - українська - (uk)](Calendr/Assets/uk.lproj/Localizable.strings)|42
 [Spanish - español - (es)](Calendr/Assets/es.lproj/Localizable.strings)|48


### PR DESCRIPTION
This PR updates the Japanese localization (`Localizable.strings`) by completing the missing translations and adjusting terms to align with the OS.

- Added missing translations: Completed all untranslated keys in `Localizable.strings`.
- Aligned with macOS Calendar: Adjusted some of the existing translations to match the phrasing used in the native macOS Calendar app (e.g., using "新規" instead of "新しい" for creating new items) to improve consistency.
- Updated documentation: Updated `MISSING_TRANSLATIONS.md` to remove the line for Japanese, as the language is now fully translated.

Please note that this PR builds upon and brings minor adjustments to the existing translations previously contributed by @yu3san3, to closely match the official macOS phrasing. If there are any issues, regressions, or better suggestions regarding these changes, please let me know.

Thank you so much for maintaining this app!