### PR TITLE
Reduce CacheDelete terminations by moving Sentry storage

### DIFF
--- a/Calendr/Utils/Sentry.swift
+++ b/Calendr/Utils/Sentry.swift
@@ -5,14 +5,24 @@
 //  Created by Paker on 15/08/2024.
 //
 
+import Foundation
 import Sentry
+
+private let legacySentryCacheEntries = [
+    "INSTALLATION",
+    "SentryCrash",
+    "SentryCrashReports",
+    "io.sentry",
+]
 
 func startSentry() -> Span? {
     guard let dsn = AppEnvironment.SENTRY_DSN else { return nil }
+    guard let storageDirectory = sentryStorageDirectory() else { return nil }
 
     SentrySDK.start { options in
         options.dsn = dsn
         options.enableAppHangTracking = false
+        options.cacheDirectoryPath = storageDirectory.path
 
         if BuildConfig.isDebug {
             options.sampleRate = 0
@@ -24,6 +34,63 @@ func startSentry() -> Span? {
     addSystemUptimeInfo(to: transaction)
 
     return transaction
+}
+
+private func sentryStorageDirectory() -> URL? {
+    let fileManager = FileManager.default
+
+    guard
+        let applicationSupportDirectory = fileManager.urls(
+            for: .applicationSupportDirectory,
+            in: .userDomainMask
+        ).first,
+        let cachesDirectory = fileManager.urls(
+            for: .cachesDirectory,
+            in: .userDomainMask
+        ).first
+    else {
+        return nil
+    }
+
+    return try? prepareSentryStorage(
+        fileManager: fileManager,
+        applicationSupportDirectory: applicationSupportDirectory,
+        cachesDirectory: cachesDirectory
+    )
+}
+
+func prepareSentryStorage(
+    fileManager: FileManager,
+    applicationSupportDirectory: URL,
+    cachesDirectory: URL
+) throws -> URL {
+    var storageDirectory = applicationSupportDirectory
+        .appendingPathComponent("Calendr", isDirectory: true)
+        .appendingPathComponent("Sentry", isDirectory: true)
+
+    try fileManager.createDirectory(
+        at: storageDirectory,
+        withIntermediateDirectories: true
+    )
+
+    var resourceValues = URLResourceValues()
+    resourceValues.isExcludedFromBackup = true
+    try? storageDirectory.setResourceValues(resourceValues)
+
+    for entry in legacySentryCacheEntries {
+        let source = cachesDirectory.appendingPathComponent(entry)
+        guard fileManager.fileExists(atPath: source.path) else { continue }
+
+        let destination = storageDirectory.appendingPathComponent(entry)
+        if !fileManager.fileExists(atPath: destination.path),
+           (try? fileManager.moveItem(at: source, to: destination)) != nil {
+            continue
+        }
+
+        try? fileManager.removeItem(at: source)
+    }
+
+    return storageDirectory
 }
 
 /**

--- a/CalendrTests/SentryTests.swift
+++ b/CalendrTests/SentryTests.swift
@@ -1,0 +1,141 @@
+//
+//  SentryTests.swift
+//  CalendrTests
+//
+
+import Foundation
+import Testing
+@testable import Calendr
+
+class SentryTests {
+
+    private let fileManager = FileManager.default
+    private var tempDirs: [URL] = []
+
+    deinit {
+        for dir in tempDirs {
+            try? fileManager.removeItem(at: dir)
+        }
+        tempDirs.removeAll()
+    }
+
+    @Test func testPrepareSentryStorage_shouldCreateDestinationAndMoveOnlySentryEntries() throws {
+
+        let root = makeTempDir()
+        let applicationSupport = root.appendingPathComponent("Application Support")
+        let caches = root.appendingPathComponent("Caches")
+
+        try fileManager.createDirectory(at: caches, withIntermediateDirectories: true)
+        try createDirectory(named: "io.sentry", in: caches)
+        try createDirectory(named: "SentryCrash", in: caches)
+        try createDirectory(named: "SentryCrashReports", in: caches)
+        try Data("installation".utf8).write(to: caches.appendingPathComponent("INSTALLATION"))
+        try Data("diagnostic".utf8).write(to: caches.appendingPathComponent("async.log"))
+        try Data("other".utf8).write(to: caches.appendingPathComponent("other.cache"))
+
+        let result = try prepareSentryStorage(
+            fileManager: fileManager,
+            applicationSupportDirectory: applicationSupport,
+            cachesDirectory: caches
+        )
+
+        let expected = applicationSupport
+            .appendingPathComponent("Calendr", isDirectory: true)
+            .appendingPathComponent("Sentry", isDirectory: true)
+        #expect(result == expected)
+        #expect(fileManager.fileExists(atPath: result.path))
+        for entry in ["SentryCrash", "SentryCrashReports", "io.sentry"] {
+            #expect(!fileManager.fileExists(atPath: caches.appendingPathComponent(entry).path))
+            #expect(fileManager.fileExists(atPath: result.appendingPathComponent(entry).path))
+            let data = try Data(
+                contentsOf: result
+                    .appendingPathComponent(entry)
+                    .appendingPathComponent("data")
+            )
+            #expect(data == Data("cached".utf8))
+        }
+        #expect(!fileManager.fileExists(atPath: caches.appendingPathComponent("INSTALLATION").path))
+        let installation = try Data(contentsOf: result.appendingPathComponent("INSTALLATION"))
+        #expect(installation == Data("installation".utf8))
+        #expect(fileManager.fileExists(atPath: caches.appendingPathComponent("async.log").path))
+        #expect(fileManager.fileExists(atPath: caches.appendingPathComponent("other.cache").path))
+    }
+
+    @Test func testPrepareSentryStorage_whenRunAgain_shouldRemainIdempotent() throws {
+
+        let root = makeTempDir()
+        let applicationSupport = root.appendingPathComponent("Application Support")
+        let caches = root.appendingPathComponent("Caches")
+
+        try fileManager.createDirectory(at: caches, withIntermediateDirectories: true)
+        try createDirectory(named: "io.sentry", in: caches)
+
+        let first = try prepareSentryStorage(
+            fileManager: fileManager,
+            applicationSupportDirectory: applicationSupport,
+            cachesDirectory: caches
+        )
+        let second = try prepareSentryStorage(
+            fileManager: fileManager,
+            applicationSupportDirectory: applicationSupport,
+            cachesDirectory: caches
+        )
+
+        #expect(first == second)
+        #expect(fileManager.fileExists(atPath: second.path))
+        #expect(!fileManager.fileExists(atPath: caches.appendingPathComponent("io.sentry").path))
+        let data = try Data(
+            contentsOf: second
+                .appendingPathComponent("io.sentry")
+                .appendingPathComponent("data")
+        )
+        #expect(data == Data("cached".utf8))
+    }
+
+    @Test func testPrepareSentryStorage_whenDestinationExists_shouldRemoveLegacyEntry() throws {
+
+        let root = makeTempDir()
+        let applicationSupport = root.appendingPathComponent("Application Support")
+        let caches = root.appendingPathComponent("Caches")
+        let destination = applicationSupport
+            .appendingPathComponent("Calendr", isDirectory: true)
+            .appendingPathComponent("Sentry", isDirectory: true)
+
+        try fileManager.createDirectory(at: caches, withIntermediateDirectories: true)
+        try fileManager.createDirectory(at: destination, withIntermediateDirectories: true)
+        try createDirectory(named: "io.sentry", in: caches, contents: "legacy")
+        try createDirectory(named: "io.sentry", in: destination, contents: "current")
+
+        let result = try prepareSentryStorage(
+            fileManager: fileManager,
+            applicationSupportDirectory: applicationSupport,
+            cachesDirectory: caches
+        )
+
+        #expect(!fileManager.fileExists(atPath: caches.appendingPathComponent("io.sentry").path))
+        let data = try Data(
+            contentsOf: result
+                .appendingPathComponent("io.sentry")
+                .appendingPathComponent("data")
+        )
+        #expect(data == Data("current".utf8))
+    }
+
+    private func makeTempDir() -> URL {
+        let dir = fileManager.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try? fileManager.createDirectory(at: dir, withIntermediateDirectories: true)
+        tempDirs.append(dir)
+        return dir
+    }
+
+    private func createDirectory(
+        named name: String,
+        in parent: URL,
+        contents: String = "cached"
+    ) throws {
+        let directory = parent.appendingPathComponent(name, isDirectory: true)
+        try fileManager.createDirectory(at: directory, withIntermediateDirectories: true)
+        try Data(contents.utf8).write(to: directory.appendingPathComponent("data"))
+    }
+}


### PR DESCRIPTION
Thanks for building Calendr, I love the app and use it every day. The repeated silent terminations were driving me a little crazy but I think I may have found the missing piece in the previous automatic-termination attempt.

#532 already retained a `ProcessInfo` activity using `.automaticTerminationDisabled`. This follow-up adds the explicit support opt-in that was absent from both the app and its Info.plist.

Apple documents `.automaticTerminationDisabled` as equivalent to `disableAutomaticTermination`, and documents that the latter has no effect unless `automaticTerminationSupportEnabled` or `NSSupportsAutomaticTermination` is set:

- [ProcessInfo activities](https://developer.apple.com/documentation/foundation/processinfo)
- [automaticTerminationSupportEnabled](https://developer.apple.com/documentation/foundation/processinfo/automaticterminationsupportenabled)

This makes the implementation different from the activity later removed in #655.

## Change

Enable automatic-termination support at launch and retain the opt-out activity for the app lifetime.

## Testing

The test build used a separate bundle ID and container so both versions could run simultaneously.
I ran stock v1.22.3 and a side-by-side patched build for a few hours on the same Mac with 3-5 GiB free:

- stock (`br.paker.Calendr`): 14 observed `CacheDeleteAppContainerCaches` terminations (`0xBADDD15C`)
- patched (`br.paker.Calendr.AutoTerminationTest`): 0 observed terminations, with the same PID throughout the test

Because CacheDelete cannot be triggered reliably, further testing on other affected Macs would be useful.

Follow-up to #392, #532, and #655.