### PR TITLE
Add a global shortcut to open the next event's link (join the next meeting)

### DIFF
--- a/Calendr/Assets/cs.lproj/Localizable.strings
+++ b/Calendr/Assets/cs.lproj/Localizable.strings
@@ -109,6 +109,7 @@
 "settings.keyboard.global_shortcuts.open_next_event_options" = "Možnosti další události";
 "settings.keyboard.global_shortcuts.open_next_reminder" = "Otevřít další připomínku";
 "settings.keyboard.global_shortcuts.open_next_reminder_options" = "Možnosti další připomínky";
+"settings.keyboard.global_shortcuts.join_next_event" = "Otevřít odkaz další události";
 
 "formatter.date.today" = "Dnes";
 "formatter.date.relative.in" = "za %@";

--- a/Calendr/Assets/de.lproj/Localizable.strings
+++ b/Calendr/Assets/de.lproj/Localizable.strings
@@ -109,6 +109,7 @@
 "settings.keyboard.global_shortcuts.open_next_event_options" = "Optionen für nächstes Ereignis";
 "settings.keyboard.global_shortcuts.open_next_reminder" = "Nächste Erinnerung öffnen";
 "settings.keyboard.global_shortcuts.open_next_reminder_options" = "Optionen für nächste Erinnerung";
+"settings.keyboard.global_shortcuts.join_next_event" = "Link des nächsten Ereignisses öffnen";
 
 "formatter.date.today" = "Heute";
 "formatter.date.relative.in" = "in %@";

--- a/Calendr/Assets/el.lproj/Localizable.strings
+++ b/Calendr/Assets/el.lproj/Localizable.strings
@@ -109,6 +109,7 @@
 "settings.keyboard.global_shortcuts.open_next_event_options" = "Επιλογές επόμενου συμβάντος";
 "settings.keyboard.global_shortcuts.open_next_reminder" = "Άνοιγμα επόμενης υπενθύμισης";
 "settings.keyboard.global_shortcuts.open_next_reminder_options" = "Επιλογές επόμενης υπενθύμισης";
+"settings.keyboard.global_shortcuts.join_next_event" = "Άνοιγμα συνδέσμου επόμενου συμβάντος";
 
 "formatter.date.today" = "Σήμερα";
 "formatter.date.relative.in" = "σε %@";

--- a/Calendr/Assets/en.lproj/Localizable.strings
+++ b/Calendr/Assets/en.lproj/Localizable.strings
@@ -109,6 +109,7 @@
 "settings.keyboard.global_shortcuts.open_next_event_options" = "Next event options";
 "settings.keyboard.global_shortcuts.open_next_reminder" = "Open next reminder";
 "settings.keyboard.global_shortcuts.open_next_reminder_options" = "Next reminder options";
+"settings.keyboard.global_shortcuts.join_next_event" = "Open next event link";
 
 "formatter.date.today" = "Today";
 "formatter.date.relative.in" = "in %@";

--- a/Calendr/Assets/es.lproj/Localizable.strings
+++ b/Calendr/Assets/es.lproj/Localizable.strings
@@ -109,6 +109,7 @@
 "settings.keyboard.global_shortcuts.open_next_event_options" = "Opciones del próximo evento";
 "settings.keyboard.global_shortcuts.open_next_reminder" = "Abrir próximo recordatorio";
 "settings.keyboard.global_shortcuts.open_next_reminder_options" = "Opciones del próximo recordatorio";
+"settings.keyboard.global_shortcuts.join_next_event" = "Abrir enlace del próximo evento";
 
 "formatter.date.today" = "Hoy";
 "formatter.date.relative.in" = "en %@";

--- a/Calendr/Assets/fr.lproj/Localizable.strings
+++ b/Calendr/Assets/fr.lproj/Localizable.strings
@@ -109,6 +109,7 @@
 "settings.keyboard.global_shortcuts.open_next_event_options" = "Options du prochain événement";
 "settings.keyboard.global_shortcuts.open_next_reminder" = "Ouvrir le prochain rappel";
 "settings.keyboard.global_shortcuts.open_next_reminder_options" = "Options du prochain rappel";
+"settings.keyboard.global_shortcuts.join_next_event" = "Ouvrir le lien du prochain événement";
 
 "formatter.date.today" = "Aujourd'hui";
 "formatter.date.relative.in" = "dans %@";

--- a/Calendr/Assets/he.lproj/Localizable.strings
+++ b/Calendr/Assets/he.lproj/Localizable.strings
@@ -109,6 +109,7 @@
 "settings.keyboard.global_shortcuts.open_next_event_options" = "אפשרויות אירוע הבא";
 "settings.keyboard.global_shortcuts.open_next_reminder" = "פתח תזכורת הבאה";
 "settings.keyboard.global_shortcuts.open_next_reminder_options" = "אפשרויות תזכורת הבאה";
+"settings.keyboard.global_shortcuts.join_next_event" = "פתח קישור אירוע הבא";
 
 "formatter.date.today" = "היום";
 "formatter.date.relative.in" = "בעוד %@";

--- a/Calendr/Assets/it.lproj/Localizable.strings
+++ b/Calendr/Assets/it.lproj/Localizable.strings
@@ -110,6 +110,7 @@
 "settings.keyboard.global_shortcuts.open_next_event_options" = "Opzioni del prossimo evento";
 "settings.keyboard.global_shortcuts.open_next_reminder" = "Aprire il prossimo promemoria";
 "settings.keyboard.global_shortcuts.open_next_reminder_options" = "Opzioni del prossimo promemoria";
+"settings.keyboard.global_shortcuts.join_next_event" = "Aprire il link del prossimo evento";
 
 "formatter.date.today" = "Oggi";
 "formatter.date.relative.in" = "in %@";

--- a/Calendr/Assets/ja.lproj/Localizable.strings
+++ b/Calendr/Assets/ja.lproj/Localizable.strings
@@ -109,6 +109,7 @@
 "settings.keyboard.global_shortcuts.open_next_event_options" = "次の予定のオプションを表示";
 "settings.keyboard.global_shortcuts.open_next_reminder" = "次のリマインダーを展開";
 "settings.keyboard.global_shortcuts.open_next_reminder_options" = "次のリマインダーのオプションを表示";
+"settings.keyboard.global_shortcuts.join_next_event" = "次の予定のリンクを展開";
 
 "formatter.date.today" = "今日";
 "formatter.date.relative.in" = "%@後";

--- a/Calendr/Assets/ko.lproj/Localizable.strings
+++ b/Calendr/Assets/ko.lproj/Localizable.strings
@@ -109,6 +109,7 @@
 "settings.keyboard.global_shortcuts.open_next_event_options" = "다음 일정 옵션";
 "settings.keyboard.global_shortcuts.open_next_reminder" = "다음 미리 알림 열기";
 "settings.keyboard.global_shortcuts.open_next_reminder_options" = "다음 미리 알림 옵션";
+"settings.keyboard.global_shortcuts.join_next_event" = "다음 일정 링크 열기";
 
 "formatter.date.today" = "오늘";
 "formatter.date.relative.in" = "%@ 후";

--- a/Calendr/Assets/nl.lproj/Localizable.strings
+++ b/Calendr/Assets/nl.lproj/Localizable.strings
@@ -107,6 +107,7 @@
 "settings.keyboard.global_shortcuts.open_next_event_options" = "Opties volgende gebeurtenis";
 "settings.keyboard.global_shortcuts.open_next_reminder" = "Volgende herinnering openen";
 "settings.keyboard.global_shortcuts.open_next_reminder_options" = "Opties volgende herinnering";
+"settings.keyboard.global_shortcuts.join_next_event" = "Link van volgende gebeurtenis openen";
 
 "formatter.date.today" = "Vandaag";
 "formatter.date.relative.in" = "over %@";

--- a/Calendr/Assets/pl.lproj/Localizable.strings
+++ b/Calendr/Assets/pl.lproj/Localizable.strings
@@ -109,6 +109,7 @@
 "settings.keyboard.global_shortcuts.open_next_event_options" = "Opcje następnego wydarzenia";
 "settings.keyboard.global_shortcuts.open_next_reminder" = "Otwórz następne przypomnienie";
 "settings.keyboard.global_shortcuts.open_next_reminder_options" = "Opcje następnego przypomnienia";
+"settings.keyboard.global_shortcuts.join_next_event" = "Otwórz link następnego wydarzenia";
 
 "formatter.date.today" = "Dzisiaj";
 "formatter.date.relative.in" = "za %@";

--- a/Calendr/Assets/pt.lproj/Localizable.strings
+++ b/Calendr/Assets/pt.lproj/Localizable.strings
@@ -109,6 +109,7 @@
 "settings.keyboard.global_shortcuts.open_next_event_options" = "Opções do próximo evento";
 "settings.keyboard.global_shortcuts.open_next_reminder" = "Abrir próximo lembrete";
 "settings.keyboard.global_shortcuts.open_next_reminder_options" = "Opções do próximo lembrete";
+"settings.keyboard.global_shortcuts.join_next_event" = "Abrir link do próximo evento";
 
 "formatter.date.today" = "Hoje";
 "formatter.date.relative.in" = "em %@";

--- a/Calendr/Assets/ru.lproj/Localizable.strings
+++ b/Calendr/Assets/ru.lproj/Localizable.strings
@@ -111,6 +111,7 @@
 "settings.keyboard.global_shortcuts.open_next_event_options" = "Открыть настройки следующего события";
 "settings.keyboard.global_shortcuts.open_next_reminder" = "Открыть следующее напоминание";
 "settings.keyboard.global_shortcuts.open_next_reminder_options" = "Открыть настройки следующего напоминания";
+"settings.keyboard.global_shortcuts.join_next_event" = "Открыть ссылку следующего события";
 
 "formatter.date.today" = "Сегодня";
 "formatter.date.relative.in" = "через %@";

--- a/Calendr/Assets/sk.lproj/Localizable.strings
+++ b/Calendr/Assets/sk.lproj/Localizable.strings
@@ -109,6 +109,7 @@
 "settings.keyboard.global_shortcuts.open_next_event_options" = "Možnosti ďalšej udalosti";
 "settings.keyboard.global_shortcuts.open_next_reminder" = "Otvoriť ďalšiu pripomienku";
 "settings.keyboard.global_shortcuts.open_next_reminder_options" = "Možnosti ďalšej pripomienky";
+"settings.keyboard.global_shortcuts.join_next_event" = "Otvoriť odkaz ďalšej udalosti";
 
 "formatter.date.today" = "Dnes";
 "formatter.date.relative.in" = "za %@";

--- a/Calendr/Assets/sq.lproj/Localizable.strings
+++ b/Calendr/Assets/sq.lproj/Localizable.strings
@@ -109,6 +109,7 @@
 "settings.keyboard.global_shortcuts.open_next_event_options" = "Opsionet e ngjarjes së ardhshme";
 "settings.keyboard.global_shortcuts.open_next_reminder" = "Hap kujtesën tjetër";
 "settings.keyboard.global_shortcuts.open_next_reminder_options" = "Opsionet e ardhshme përkujtues";
+"settings.keyboard.global_shortcuts.join_next_event" = "Hap lidhjen e ngjarjes së radhës";
 
 "formatter.date.today" = "Sot";
 "formatter.date.relative.in" = "në %@";

--- a/Calendr/Assets/sv.lproj/Localizable.strings
+++ b/Calendr/Assets/sv.lproj/Localizable.strings
@@ -109,6 +109,7 @@
 "settings.keyboard.global_shortcuts.open_next_event_options" = "Nästa händelsealternativ";
 "settings.keyboard.global_shortcuts.open_next_reminder" = "Öppna nästa påminnelse";
 "settings.keyboard.global_shortcuts.open_next_reminder_options" = "Nästa påminnelsealternativ";
+"settings.keyboard.global_shortcuts.join_next_event" = "Öppna länk för nästa händelse";
 
 "formatter.date.today" = "Idag";
 "formatter.date.relative.in" = "om %@";

--- a/Calendr/Assets/tr.lproj/Localizable.strings
+++ b/Calendr/Assets/tr.lproj/Localizable.strings
@@ -109,6 +109,7 @@
 "settings.keyboard.global_shortcuts.open_next_event_options" = "Sonraki etkinlik seçenekleri";
 "settings.keyboard.global_shortcuts.open_next_reminder" = "Sonraki hatırlatıcıyı aç";
 "settings.keyboard.global_shortcuts.open_next_reminder_options" = "Sonraki hatırlatıcı seçenekleri";
+"settings.keyboard.global_shortcuts.join_next_event" = "Sonraki etkinlik bağlantısını aç";
 
 "formatter.date.today" = "Bugün";
 "formatter.date.relative.in" = "%@ içinde";

--- a/Calendr/Assets/uk.lproj/Localizable.strings
+++ b/Calendr/Assets/uk.lproj/Localizable.strings
@@ -109,6 +109,7 @@
 "settings.keyboard.global_shortcuts.open_next_event_options" = "Відкрити налаштування наступної події";
 "settings.keyboard.global_shortcuts.open_next_reminder" = "Відкрити наступне нагадування";
 "settings.keyboard.global_shortcuts.open_next_reminder_options" = "Відкрити налаштування наступного нагадування";
+"settings.keyboard.global_shortcuts.join_next_event" = "Відкрити посилання наступної події";
 
 "formatter.date.today" = "Сьогодні";
 "formatter.date.relative.in" = "через %@";

--- a/Calendr/Assets/zh-Hans.lproj/Localizable.strings
+++ b/Calendr/Assets/zh-Hans.lproj/Localizable.strings
@@ -109,6 +109,7 @@
 "settings.keyboard.global_shortcuts.open_next_event_options" = "下一个事件选项";
 "settings.keyboard.global_shortcuts.open_next_reminder" = "打开下一个提醒";
 "settings.keyboard.global_shortcuts.open_next_reminder_options" = "下一个提醒选项";
+"settings.keyboard.global_shortcuts.join_next_event" = "打开下一个事件链接";
 
 "formatter.date.today" = "今日";
 "formatter.date.relative.in" = "在 %@ 内";

--- a/Calendr/Assets/zh-Hant-TW.lproj/Localizable.strings
+++ b/Calendr/Assets/zh-Hant-TW.lproj/Localizable.strings
@@ -109,6 +109,7 @@
 "settings.keyboard.global_shortcuts.open_next_event_options" = "下一個事件選項";
 "settings.keyboard.global_shortcuts.open_next_reminder" = "打開下一個提醒";
 "settings.keyboard.global_shortcuts.open_next_reminder_options" = "下一個提醒選項";
+"settings.keyboard.global_shortcuts.join_next_event" = "打開下一個事件連結";
 
 "formatter.date.today" = "今天";
 "formatter.date.relative.in" = "在 %@ 之後";

--- a/Calendr/Constants/Strings.generated.swift
+++ b/Calendr/Constants/Strings.generated.swift
@@ -300,6 +300,8 @@ internal enum Strings {
     }
     internal enum Keyboard {
       internal enum GlobalShortcuts {
+        /// Open next event link
+        internal static let joinNextEvent = Strings.tr("Localizable", "settings.keyboard.global_shortcuts.join_next_event", fallback: "Open next event link")
         /// Open calendar
         internal static let openCalendar = Strings.tr("Localizable", "settings.keyboard.global_shortcuts.open_calendar", fallback: "Open calendar")
         /// Open next event

--- a/Calendr/Main/MainViewController.swift
+++ b/Calendr/Main/MainViewController.swift
@@ -892,6 +892,10 @@ class MainViewController: NSViewController {
                 self?.reminderStatusItemClickHandler.rightClick.onNext(())
             }
         }
+
+        KeyboardShortcuts.onKeyUp(for: .joinNextEvent) { [weak self] in
+            self?.nextEventViewModel.openNextEventLink()
+        }
     }
 
     private func setUpDeeplink() {

--- a/Calendr/MenuBar/NextEventViewModel.swift
+++ b/Calendr/MenuBar/NextEventViewModel.swift
@@ -418,6 +418,17 @@ class NextEventViewModel {
         restoreStatusItemPreferredPosition(statusItemName, in: localStorage)
     }
 
+    // Reuses the event currently shown by the status item, so it's a no-op while the item
+    // is hidden and naturally skips conflicting events (their merged group has no link).
+    func openNextEventLink() {
+        guard
+            let event = try? nextEvent.value()?.event,
+            let link = event.detectLink(using: workspace)
+        else { return }
+
+        workspace.open(link)
+    }
+
     func makeContextMenuViewModel() -> (any ContextMenuViewModel)? {
         guard
             let event = try? nextEvent.value()?.event,

--- a/Calendr/Settings/KeyboardViewController.swift
+++ b/Calendr/Settings/KeyboardViewController.swift
@@ -78,6 +78,7 @@ class KeyboardViewController: NSViewController, SettingsUI {
             makeGlobalShortcut(text: GlobalShortcuts.openCalendar, for: .showMainPopover),
             makeGlobalShortcut(text: GlobalShortcuts.openNextEvent, for: .showNextEventPopover),
             makeGlobalShortcut(text: GlobalShortcuts.openNextEventOptions, for: .showNextEventOptions),
+            makeGlobalShortcut(text: GlobalShortcuts.joinNextEvent, for: .joinNextEvent),
             makeGlobalShortcut(text: GlobalShortcuts.openNextReminder, for: .showNextReminderPopover),
             makeGlobalShortcut(text: GlobalShortcuts.openNextReminderOptions, for: .showNextReminderOptions)
         ])
@@ -134,4 +135,5 @@ extension KeyboardShortcuts.Name {
     static let showNextEventOptions = Self("showNextEventOptions")
     static let showNextReminderPopover = Self("showNextReminderPopover")
     static let showNextReminderOptions = Self("showNextReminderOptions")
+    static let joinNextEvent = Self("joinNextEvent")
 }

--- a/CalendrTests/NextEventViewModelTests.swift
+++ b/CalendrTests/NextEventViewModelTests.swift
@@ -1050,8 +1050,6 @@ class NextEventViewModelTests {
 
     @Test func testOpenNextEventLink_statusItemDisabled_doesNothing() {
 
-        // The shortcut reuses whatever the status item is showing, so it stays a no-op while
-        // the item is hidden, matching the maintainer's requested behavior.
         let viewModel = makeViewModel(type: .event)
 
         settings.toggleStatusItem.onNext(false)

--- a/CalendrTests/NextEventViewModelTests.swift
+++ b/CalendrTests/NextEventViewModelTests.swift
@@ -1052,22 +1052,9 @@ class NextEventViewModelTests {
 
         // The shortcut reuses whatever the status item is showing, so it stays a no-op while
         // the item is hidden, matching the maintainer's requested behavior.
-        let settings = MockNextEventSettings(showItem: false)
-        let viewModel = NextEventViewModel(
-            type: .event,
-            localStorage: localStorage,
-            settings: settings,
-            nextEventCalendars: calendarsSubject,
-            dateProvider: dateProvider,
-            calendarService: calendarService,
-            geocoder: geocoder,
-            weatherService: weatherService,
-            workspace: workspace,
-            screenProvider: screenProvider,
-            isShowingDetailsModal: .init(value: false),
-            scheduler: scheduler,
-            soundPlayer: soundPlayer
-        )
+        let viewModel = makeViewModel(type: .event)
+
+        settings.toggleStatusItem.onNext(false)
 
         var hasEvent: Bool?
         viewModel.hasEvent

--- a/CalendrTests/NextEventViewModelTests.swift
+++ b/CalendrTests/NextEventViewModelTests.swift
@@ -997,6 +997,153 @@ class NextEventViewModelTests {
         #expect(hasEvent == false)
     }
 
+    @Test func testOpenNextEventLink_withMeetingLink_opensLink() {
+
+        let viewModel = makeViewModel(type: .event)
+
+        var openedURL: URL?
+        workspace.didOpenURL = { openedURL = $0 }
+
+        calendarService.changeEvents([
+            .make(start: now, end: now + 1, url: URL(string: "https://meet.google.com/abc-defg-hij")!)
+        ])
+        scheduler.advance(.seconds(1))
+
+        viewModel.openNextEventLink()
+
+        #expect(openedURL?.absoluteString == "https://meet.google.com/abc-defg-hij")
+    }
+
+    @Test func testOpenNextEventLink_withPlainLink_opensLink() {
+
+        let viewModel = makeViewModel(type: .event)
+
+        var openedURL: URL?
+        workspace.didOpenURL = { openedURL = $0 }
+
+        calendarService.changeEvents([
+            .make(start: now, end: now + 1, url: URL(string: "https://someurl.com")!)
+        ])
+        scheduler.advance(.seconds(1))
+
+        viewModel.openNextEventLink()
+
+        #expect(openedURL?.absoluteString == "https://someurl.com")
+    }
+
+    @Test func testOpenNextEventLink_withoutLink_doesNothing() {
+
+        let viewModel = makeViewModel(type: .event)
+
+        var openedURL: URL?
+        workspace.didOpenURL = { openedURL = $0 }
+
+        calendarService.changeEvents([
+            .make(start: now, end: now + 1, location: "some location")
+        ])
+        scheduler.advance(.seconds(1))
+
+        viewModel.openNextEventLink()
+
+        #expect(openedURL == nil)
+    }
+
+    @Test func testOpenNextEventLink_statusItemDisabled_doesNothing() {
+
+        // The shortcut reuses whatever the status item is showing, so it stays a no-op while
+        // the item is hidden, matching the maintainer's requested behavior.
+        let settings = MockNextEventSettings(showItem: false)
+        let viewModel = NextEventViewModel(
+            type: .event,
+            localStorage: localStorage,
+            settings: settings,
+            nextEventCalendars: calendarsSubject,
+            dateProvider: dateProvider,
+            calendarService: calendarService,
+            geocoder: geocoder,
+            weatherService: weatherService,
+            workspace: workspace,
+            screenProvider: screenProvider,
+            isShowingDetailsModal: .init(value: false),
+            scheduler: scheduler,
+            soundPlayer: soundPlayer
+        )
+
+        var hasEvent: Bool?
+        viewModel.hasEvent
+            .bind { hasEvent = $0 }
+            .disposed(by: disposeBag)
+
+        var openedURL: URL?
+        workspace.didOpenURL = { openedURL = $0 }
+
+        calendarService.changeEvents([
+            .make(start: now, end: now + 1, url: URL(string: "https://meet.google.com/abc-defg-hij")!)
+        ])
+        scheduler.advance(.seconds(1))
+
+        #expect(hasEvent == false)
+
+        viewModel.openNextEventLink()
+
+        #expect(openedURL == nil)
+    }
+
+    @Test func testOpenNextEventLink_skippedEvent_opensFollowingEvent() throws {
+
+        let viewModel = makeViewModel(type: .event)
+
+        var openedURL: URL?
+        workspace.didOpenURL = { openedURL = $0 }
+
+        calendarService.changeEvents([
+            .make(id: "1", start: now, end: now + 1, url: URL(string: "https://meet.google.com/first")!),
+            .make(id: "2", start: now + 1, end: now + 2, url: URL(string: "https://meet.google.com/second")!)
+        ])
+        scheduler.advance(.seconds(1))
+
+        // skip the nearest event, so the status item advances past it
+        try #require(viewModel.makeContextMenuViewModel() as? EventOptionsViewModel).triggerAction(.skip)
+        scheduler.advance(.seconds(1))
+
+        // the shortcut must honor the skip and open the following event's link
+        viewModel.openNextEventLink()
+
+        #expect(openedURL?.absoluteString == "https://meet.google.com/second")
+    }
+
+    @Test func testOpenNextEventLink_conflictingEvents_doesNothing() {
+
+        let viewModel = makeViewModel(type: .event)
+
+        var openedURL: URL?
+        workspace.didOpenURL = { openedURL = $0 }
+
+        // two events starting at the same time are merged into a single group event with no
+        // link, so the shortcut must not just open the first one
+        calendarService.changeEvents([
+            .make(id: "1", start: now, end: now + 1, url: URL(string: "https://meet.google.com/first")!),
+            .make(id: "2", start: now, end: now + 1, url: URL(string: "https://meet.google.com/second")!)
+        ])
+        scheduler.advance(.seconds(1))
+
+        viewModel.openNextEventLink()
+
+        #expect(openedURL == nil)
+    }
+
+    @Test func testOpenNextEventLink_withoutEvent_doesNothing() {
+
+        let viewModel = makeViewModel(type: .event)
+
+        var openedURL: URL?
+        workspace.didOpenURL = { openedURL = $0 }
+
+        viewModel.openNextEventLink()
+
+        #expect(openedURL == nil)
+    }
+
     @Test func testNextEvent_skipped_fromEventDetails() throws {
 
         let viewModel = makeViewModel(type: .event)


### PR DESCRIPTION
### What

Adds a configurable global keyboard shortcut, **"Open next event link"**, that opens the link for your next (or in-progress) event without reaching for the mouse. If the event has a detected meeting link it opens that, otherwise it opens any plain link on the event.

Closes #703.

<img width="660" height="833" alt="image" src="https://github.com/user-attachments/assets/9573c7b8-2dec-4fdc-b63d-0bc368f29d7c" />


### Updated after review

Per the discussion on the issue, this now takes the simplest possible approach: it opens whatever the next-event menu bar item is already showing.

- If that item is hidden, the shortcut does nothing.
- If two events start at the same time, the menu bar groups them and the group has no link, so the shortcut does nothing rather than guessing which one to open.
- Reminders are out of scope for this PR.

### Reuses what's already there

- Link detection is the same logic behind the current "join" button (Zoom, Teams, Google Meet, Webex, FaceTime, and plain links), including notes.
- Opening the link uses the same path as the rest of the app.
- The event itself comes straight from the value the status item already publishes, skips included.

The `NextEventViewModel` diff is now a single small method.

### Localization

Added the new label and translations for all supported languages.

### Tests

Added tests for: meeting link opens, plain link opens, no link does nothing, no event does nothing, status item hidden does nothing, skipped events are respected, and conflicting events do nothing.
