### PR TITLE
Show reminders url + flag + tags

### DIFF
--- a/Calendr.xcodeproj/project.pbxproj
+++ b/Calendr.xcodeproj/project.pbxproj
@@ -660,7 +660,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 1.22.4;
+				MARKETING_VERSION = 1.22.5;
 				PRODUCT_BUNDLE_IDENTIFIER = br.paker.Calendr;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Calendr/ObjC/Calendr-Bridging-Header.h";
@@ -696,7 +696,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 1.22.4;
+				MARKETING_VERSION = 1.22.5;
 				PRODUCT_BUNDLE_IDENTIFIER = br.paker.Calendr;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/Calendr/Constants/Icons.swift
+++ b/Calendr/Constants/Icons.swift
@@ -61,6 +61,7 @@ enum Icons {
         static let video_fill = NSImage(systemName: "video.fill")
         static let skip = NSImage(systemName: "forward")
         static let recurrence = NSImage(systemName: "repeat")
+        static let flagged = NSImage(systemName: "flag.fill")
     }
 
     enum Reminder {

--- a/Calendr/Events/EventList/EventView.swift
+++ b/Calendr/Events/EventList/EventView.swift
@@ -18,10 +18,12 @@ class EventView: NSView {
 
     private let birthdayIcon = NSImageView()
     private let recurrenceIcon = NSImageView()
+    private let flaggedIcon = NSImageView()
     private let priority = Label()
     private let title = Label()
     private let subtitle = Label()
     private let subtitleLink = Label(align: .left)
+    private let tags = Label()
     private let duration = Label()
     private let relativeDuration = Label()
     private let progress = NSView()
@@ -66,6 +68,11 @@ class EventView: NSView {
                 priority.textColor = viewModel.color
                 priority.stringValue = viewModel.priority ?? ""
                 priority.isHidden = viewModel.priority == nil
+
+                flaggedIcon.isHidden = !viewModel.flagged
+
+                tags.isHidden = viewModel.tags.isEmpty
+                tags.stringValue = viewModel.tags.map { "#\($0)" }.joined(separator: " ")
 
                 completeBtn.contentTintColor = viewModel.color
                 completeBtn.isHidden = false
@@ -113,7 +120,7 @@ class EventView: NSView {
         hoverLayer.cornerRadius = cornerRadius
         layer?.addSublayer(hoverLayer)
 
-        [birthdayIcon, recurrenceIcon, completeBtn, priority, relativeDuration].forEach {
+        [birthdayIcon, recurrenceIcon, flaggedIcon, completeBtn, priority, relativeDuration].forEach {
             $0.setContentHuggingPriority(.required, for: .horizontal)
             $0.setContentCompressionResistancePriority(.required, for: .horizontal)
         }
@@ -122,6 +129,9 @@ class EventView: NSView {
 
         priority.isHidden = true
         priority.font = .systemFont(ofSize: 13)
+
+        flaggedIcon.isHidden = true
+        flaggedIcon.contentTintColor = .systemOrange
 
         birthdayIcon.isHidden = true
         birthdayIcon.contentTintColor = .systemRed
@@ -149,6 +159,13 @@ class EventView: NSView {
         subtitleLink.textColor = .secondaryLabelColor
         subtitleLink.font = .systemFont(ofSize: 11)
 
+        tags.isHidden = true
+        tags.lineBreakMode = .byWordWrapping
+        tags.maximumNumberOfLines = 2
+        tags.cell?.truncatesLastVisibleLine = true
+        tags.textColor = viewModel.color
+        tags.font = .systemFont(ofSize: 10)
+
         colorBar.wantsLayer = true
         colorBar.layer?.cornerRadius = 2
 
@@ -159,7 +176,7 @@ class EventView: NSView {
         colorBar.center(in: colorBarContainer, orientation: .vertical)
         colorBar.height(equalTo: colorBarContainer, constant: -(cornerRadius + 4))
 
-        let titleStackView = NSStackView(views: [birthdayIcon, completeBtn, priority, title, recurrenceIcon])
+        let titleStackView = NSStackView(views: [birthdayIcon, completeBtn, priority, title, flaggedIcon, recurrenceIcon])
             .with(spacing: 3)
             .with(alignment: .firstBaseline)
 
@@ -177,6 +194,13 @@ class EventView: NSView {
             .bind(to: linkStackView.rx.isHidden)
             .disposed(by: disposeBag)
 
+        viewModel.showDetails
+            .map { [viewModel] in
+                !$0 || viewModel.tags.isEmpty
+            }
+            .bind(to: tags.rx.isHidden)
+            .disposed(by: disposeBag)
+
         let durationStackView = NSStackView(views: [duration, relativeDuration])
         duration.setContentHuggingPriority(.fittingSizeCompression, for: .horizontal)
         durationStackView.setHuggingPriority(.defaultHigh, for: .horizontal)
@@ -185,7 +209,7 @@ class EventView: NSView {
             .bind(to: durationStackView.rx.isHidden)
             .disposed(by: disposeBag)
 
-        let eventStackView = NSStackView(views: [titleStackView, subtitle, linkStackView, durationStackView])
+        let eventStackView = NSStackView(views: [titleStackView, subtitle, linkStackView, durationStackView, tags])
             .with(orientation: .vertical)
             .with(spacing: 3)
             .with(insets: .init(vertical: cornerRadius / 2))
@@ -353,6 +377,11 @@ class EventView: NSView {
                     return icon.with(pointSize: 12 * scaling)
                 }
                 .bind(to: completeBtn.rx.image)
+                .disposed(by: disposeBag)
+
+            Scaling.observable
+                .map { Icons.Event.flagged.with(pointSize: 10 * $0) }
+                .bind(to: flaggedIcon.rx.image)
                 .disposed(by: disposeBag)
 
             viewModel.relativeDuration

--- a/Calendr/Events/EventList/EventViewModel.swift
+++ b/Calendr/Events/EventList/EventViewModel.swift
@@ -22,6 +22,8 @@ class EventViewModel {
     let end: Date
     let link: EventLink?
     let priority: String?
+    let flagged: Bool
+    let tags: [String]
 
     let duration: Observable<String>
     let isInProgress: Observable<Bool>
@@ -93,6 +95,8 @@ class EventViewModel {
         end = event.end
         barStyle = event.status ~= .maybe ? .bordered : .filled
         link = event.detectLink(using: workspace)
+        flagged = event.flagged
+        tags = event.tags
 
         priority = switch event.priority {
             case .high: "!!!"

--- a/Calendr/Extensions/NSObject+KVC.swift
+++ b/Calendr/Extensions/NSObject+KVC.swift
@@ -27,16 +27,12 @@ enum KVCError: LocalizedError {
 extension NSObject {
 
     func safeValue<T>(forKey key: String) throws -> T {
-        var result: Any?
-        var exception: NSException?
 
-        ExceptionCatcher.try {
-            result = self.value(forKey: key)
-        } catch: { ex in
-            exception = ex
-        }
+        var keyExists = ObjCBool(false)
 
-        guard exception == nil else {
+        let result = ExceptionCatcher.safeValue(forKey: key, in: self, keyExists: &keyExists)
+
+        guard keyExists.boolValue else {
             throw KVCError.unknownKey(key: key, in: typeName(self))
         }
 

--- a/Calendr/MenuBar/NextEventViewModel.swift
+++ b/Calendr/MenuBar/NextEventViewModel.swift
@@ -531,7 +531,9 @@ private func fakeEvent(
         timeZone: nil,
         hasRecurrenceRules: false,
         priority: nil,
-        attachments: []
+        attachments: [],
+        flagged: false,
+        tags: []
     )
 }
 

--- a/Calendr/Mocks/Factories/EventModel+Factory.swift
+++ b/Calendr/Mocks/Factories/EventModel+Factory.swift
@@ -26,7 +26,9 @@ extension EventModel {
         participants: [Participant] = [],
         timeZone: TimeZone? = nil,
         hasRecurrenceRules: Bool = false,
-        priority: Priority? = nil
+        priority: Priority? = nil,
+        flagged: Bool = false,
+        tags: [String] = []
     ) -> EventModel {
 
         .init(
@@ -46,7 +48,9 @@ extension EventModel {
             timeZone: timeZone,
             hasRecurrenceRules: hasRecurrenceRules,
             priority: priority,
-            attachments: []
+            attachments: [],
+            flagged: flagged,
+            tags: tags
         )
     }
 }

--- a/Calendr/Models/EventModel.swift
+++ b/Calendr/Models/EventModel.swift
@@ -25,6 +25,8 @@ struct EventModel: Equatable {
     let hasRecurrenceRules: Bool
     let priority: Priority?
     let attachments: [Attachment]
+    let flagged: Bool
+    let tags: [String]
 }
 
 enum EventStatus: Comparable {

--- a/Calendr/ObjC/ExceptionCatcher.h
+++ b/Calendr/ObjC/ExceptionCatcher.h
@@ -9,7 +9,6 @@
 
 @interface ExceptionCatcher : NSObject
 
-+ (void)tryBlock:(void (^_Nonnull)(void))tryBlock
-      catchBlock:(void (^_Nonnull)(NSException * _Nullable exception))catchBlock;
++ (nullable id)safeValueForKey:(NSString * _Nonnull)key in:(id _Nonnull)object keyExists:(BOOL * _Nonnull)keyExists;
 
 @end

--- a/Calendr/ObjC/ExceptionCatcher.m
+++ b/Calendr/ObjC/ExceptionCatcher.m
@@ -9,13 +9,14 @@
 
 @implementation ExceptionCatcher
 
-+ (void)tryBlock:(void (^_Nonnull)(void))tryBlock
-      catchBlock:(void (^_Nonnull)(NSException * _Nullable exception))catchBlock
-{
++ (nullable id)safeValueForKey:(NSString * _Nonnull)key in:(id _Nonnull)object keyExists:(BOOL * _Nonnull)keyExists {
     @try {
-        tryBlock();
+        id value = [object valueForKey:key];
+        *keyExists = YES;
+        return value;
     } @catch (NSException *exception) {
-        catchBlock(exception);
+        *keyExists = NO;
+        return nil;
     }
 }
 

--- a/Calendr/Providers/CalendarServiceProvider.swift
+++ b/Calendr/Providers/CalendarServiceProvider.swift
@@ -706,7 +706,9 @@ private extension EventModel {
             timeZone: calendar.isSubscribed || calendar.isDelegate ? nil : event.timeZone,
             hasRecurrenceRules: event.hasRecurrenceRules || event.isDetached,
             priority: nil,
-            attachments: event.attachments
+            attachments: event.attachments,
+            flagged: false,
+            tags: []
         )
     }
 
@@ -717,6 +719,8 @@ private extension EventModel {
             let date = dateProvider.calendar.date(from: dueDateComponents)
         else { return nil }
 
+        let remReminder = try? REMReminder(from: reminder)
+
         self.init(
             id: reminder.calendarItemIdentifier,
             externalId: reminder.calendarItemExternalIdentifier,
@@ -726,7 +730,7 @@ private extension EventModel {
             location: reminder.location, // doesn't work
             coordinates: nil,
             notes: reminder.notes,
-            url: reminder.url, // doesn't work
+            url: remReminder?.url ?? reminder.url,
             isAllDay: dueDateComponents.hour == nil,
             type: .reminder(completed: reminder.isCompleted),
             calendar: .init(from: calendar),
@@ -734,8 +738,39 @@ private extension EventModel {
             timeZone: calendar.isSubscribed || calendar.isDelegate ? nil : reminder.timeZone,
             hasRecurrenceRules: reminder.hasRecurrenceRules,
             priority: .init(from: reminder.priority),
-            attachments: reminder.attachments // doesn't work
+            attachments: reminder.attachments, // not worth it (private api)
+            flagged: remReminder?.flagged ?? false,
+            tags: remReminder?.tags ?? []
         )
+    }
+}
+
+/**
+ * This is a reverse-engineered subset of the reminder class from `ReminderKit.framework`, which is a private api.
+ */
+private struct REMReminder {
+
+    let url: URL?
+    let flagged: Bool
+    let tags: [String]
+
+    init(from ekrem: EKReminder) throws {
+        let object = try ekrem.safeValue(forKey: "persistentObject") as NSObject
+        let reminder = try object.safeValue(forKey: "reminder") as NSObject
+
+        self.flagged = (try? reminder.safeValue(forKey: "flagged")) ?? false
+
+        let hashtags = try? reminder.safeValue(forKey: "hashtags") as Set<NSObject>
+
+        self.tags = hashtags?.compactMap { try? $0.safeValue(forKey: "name") as String }.sorted() ?? []
+
+        let attachments = try? reminder.safeValue(forKey: "attachments") as [NSObject]
+
+        self.url = try? attachments?.first { $0.className == "REMURLAttachment" }?.safeValue(forKey: "url")
+
+        // We could technically also get all "REMImageAttachment" here,
+        // but they are stored in a folder different than regular EventKit attachments,
+        // so we would have to ask the user for another permission.
     }
 }
 

--- a/Calendr/Utils/Inspect.swift
+++ b/Calendr/Utils/Inspect.swift
@@ -7,6 +7,7 @@
 
 #if DEBUG
 
+import Foundation
 import ObjectiveC
 
 func inspect(_ obj: AnyObject) {

--- a/Calendr/Utils/Inspect.swift
+++ b/Calendr/Utils/Inspect.swift
@@ -1,0 +1,101 @@
+//
+//  Inspect.swift
+//  Calendr
+//
+//  Created by Paker on 24/07/2026.
+//
+
+#if DEBUG
+
+import ObjectiveC
+
+func inspect(_ obj: AnyObject) {
+    inspect(obj.classForCoder)
+}
+
+func inspect(_ cls: AnyClass, includeMethods: Bool = false) {
+    var currentClass: AnyClass? = cls
+
+    while let current = currentClass, current != NSObject.self {
+        print("=== \(String(cString: class_getName(current))) ===")
+        var count: UInt32 = 0
+
+        // 1. Properties
+        if let properties = class_copyPropertyList(current, &count) {
+            for i in 0..<Int(count) {
+                let name = String(cString: property_getName(properties[i]))
+                let type = getType(property: properties[i])
+                print("Property: \(name) - \(type)")
+            }
+            free(properties)
+        }
+
+        // 2. Ivars
+        if let ivars = class_copyIvarList(current, &count) {
+            for i in 0..<Int(count) {
+                if let cName = ivar_getName(ivars[i]) {
+                    let type = getType(ivar: ivars[i])
+                    print("Ivar: \(String(cString: cName)) - \(type)")
+                }
+            }
+            free(ivars)
+        }
+
+        // 3. Methods
+        if includeMethods, let methods = class_copyMethodList(current, &count) {
+            for i in 0..<Int(count) {
+                let name = NSStringFromSelector(method_getName(methods[i]))
+                print("Method: \(name)")
+            }
+            free(methods)
+        }
+
+        print("\n")
+        currentClass = class_getSuperclass(current)
+    }
+}
+
+private func getType(property: objc_property_t) -> String {
+    guard let attributes = property_getAttributes(property) else { return "unknown" }
+    let attrString = String(cString: attributes)
+    return parseType(attrString)
+}
+
+private func getType(ivar: Ivar) -> String {
+    guard let attributes = ivar_getTypeEncoding(ivar) else { return "unknown" }
+    let attrString = String(cString: attributes)
+    return parseType(attrString)
+}
+
+private func parseType(_ attrString: String) -> String {
+
+    // Split the comma-separated attributes (the type is always the first element)
+    guard let typeAttribute = attrString.split(separator: ",").first else { return "unknown" }
+
+    // Handle Object Types: T@"NSString" -> NSString
+    if typeAttribute.hasPrefix("T@\"") && typeAttribute.hasSuffix("\"") {
+        let start = typeAttribute.index(typeAttribute.startIndex, offsetBy: 3)
+        let end = typeAttribute.index(typeAttribute.endIndex, offsetBy: -1)
+        return String(typeAttribute[start..<end])
+    }
+
+    // Handle Primitive Types
+    let typeCode = String(typeAttribute.dropFirst())
+    let primitiveMap: [String: String] = [
+        "c": "Int8",
+        "C": "UInt8",
+        "s": "Int16",
+        "S": "UInt16",
+        "i": "Int32",
+        "I": "UInt32",
+        "q": "Int",
+        "Q": "UInt",
+        "f": "Float",
+        "d": "Double",
+        "B": "Bool"
+    ]
+
+    return primitiveMap[typeCode] ?? typeCode
+}
+
+#endif


### PR DESCRIPTION
This pull request introduces support for displaying **flagged** reminders and **URL** in the event list and improves the extraction of private reminder properties using reverse-engineered APIs.

- Close #199
- Close #350
- Close #466

<br><img width="199" height="80" alt="Screenshot 2026-07-24 at 23 32 56" src="https://github.com/user-attachments/assets/173bf94c-20a3-4fc4-886d-399145778d31" /><br>

**Flagged Reminder Support**
* Added a `flagged` property to `EventModel` and related view models, enabling the UI to display a flagged icon for flagged reminders.
* Updated the reminder extraction logic in `CalendarServiceProvider` to use a reverse-engineered `REMReminder` struct for accessing `URL`, `flagged` and `hashtags` properties via private APIs.

**Key-Value Coding (KVC) Improvements**
* Replaced the previous Objective-C exception handling approach, which was known to cause memory leaks in case of missing keys, with a new `safeValueForKey:in:keyExists:` method in `ExceptionCatcher`, improving the robustness of KVC error handling.

**Debugging Utilities**
* Added a new `Inspect.swift` debug utility to print properties, ivars, and methods of Objective-C classes for easier reverse engineering and debugging.