### PR TITLE
Search for events in the entire year

### DIFF
--- a/Calendr.xcodeproj/project.pbxproj
+++ b/Calendr.xcodeproj/project.pbxproj
@@ -660,7 +660,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 1.22.6;
+				MARKETING_VERSION = 1.23.0;
 				PRODUCT_BUNDLE_IDENTIFIER = br.paker.Calendr;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Calendr/ObjC/Calendr-Bridging-Header.h";
@@ -696,7 +696,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 1.22.6;
+				MARKETING_VERSION = 1.23.0;
 				PRODUCT_BUNDLE_IDENTIFIER = br.paker.Calendr;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/Calendr/Calendar/CalendarViewModel.swift
+++ b/Calendr/Calendar/CalendarViewModel.swift
@@ -11,7 +11,7 @@ import RxSwift
 class CalendarViewModel {
 
     let cellViewModelsObservable: Observable<[CalendarCellViewModel]>
-    let focusedDateEventsObservable: Observable<DateEvents>
+    let eventListObservable: Observable<DateEvents>
 
     let title: Observable<String>
     let weekCount: Observable<Int>
@@ -124,27 +124,30 @@ class CalendarViewModel {
         }
         .share(replay: 1)
 
-        let dateRange = Observable
-            .combineLatest(dateCellsObservable, settings.futureEventsDays)
-            .compactMap { cells, futureEventsDays -> (start: Date, end: Date)? in
-                guard
-                    let firstVisibleDate = cells.first?.date,
-                    let lastVisibleDate = cells.last?.date,
-                    let endDate = dateProvider.calendar.date(
-                        byAdding: DateComponents(day: futureEventsDays),
-                        to: lastVisibleDate
-                    )
-                else {
-                    return nil
-                }
-                return (firstVisibleDate, endDate)
+        // Range for fetching events in the focused year
+        let fetchRangeObservable = dateObservable
+            .compactMap {
+                dateProvider.calendar.dateInterval(of: .year, for: $0)
             }
-            .distinctUntilChanged(==)
-            .share(replay: 1)
+            .distinctUntilChanged()
+            .compactMap { interval -> (start: Date, end: Date)? in
+                guard
+                    let startDate = dateProvider.calendar.date(
+                        byAdding: DateComponents(day: -7),
+                        to: interval.start
+                    ),
+                    let endDate = dateProvider.calendar.date(
+                        byAdding: DateComponents(month: +1),
+                        to: interval.end
+                    )
+                else { return nil }
+
+                return (startDate, endDate)
+            }
 
         // Get events for current dates
         let eventsObservable = Observable.combineLatest(
-            dateRange,
+            fetchRangeObservable,
             enabledCalendars.startWith([])
         )
         .repeat(when: calendarService.changeObservable)
@@ -308,8 +311,14 @@ class CalendarViewModel {
             .distinctUntilChanged()
             .share(replay: 1)
 
-        focusedDateEventsObservable = cellViewModelsObservable
-            .compactMap { cellViewModels in
+        eventListObservable = Observable
+            .combineLatest(cellViewModelsObservable, searchObservable.map(\.isNotBlank), filteredEventsObservable)
+            .compactMap { cellViewModels, hasSearch, filteredEvents in
+
+                if hasSearch, let filteredEvents {
+                    return DateEvents(date: .distantPast, events: filteredEvents.suffix(Constants.maxSearchResults))
+                }
+
                 guard
                     let focused = cellViewModels.first(where: \.isHovered) ?? cellViewModels.first(where: \.isSelected)
                 else { return nil }
@@ -364,4 +373,5 @@ private enum Constants {
 
     static let cellSize: CGFloat = 25
     static let weekNumberCellRatio: CGFloat = 0.85
+    static let maxSearchResults: Int = 12
 }

--- a/Calendr/Main/MainViewController.swift
+++ b/Calendr/Main/MainViewController.swift
@@ -179,7 +179,7 @@ class MainViewController: NSViewController {
 
         titleLabel = Label(scaling: calendarViewModel.textScaling)
 
-        let eventListEventsObservable = calendarViewModel.focusedDateEventsObservable
+        let eventListEventsObservable = calendarViewModel.eventListObservable
             .debounce(.milliseconds(50), scheduler: MainScheduler.instance)
             .share(replay: 1)
 

--- a/CalendrTests/CalendarViewModelSearchTests.swift
+++ b/CalendrTests/CalendarViewModelSearchTests.swift
@@ -1,0 +1,124 @@
+//
+//  CalendarViewModelSearchTests.swift
+//  CalendrTests
+//
+//  Created by Paker on 29/07/2026.
+//
+
+import AppKit
+import RxSwift
+import Testing
+@testable import Calendr
+
+class CalendarViewModelSearchTests {
+
+    private let disposeBag = DisposeBag()
+
+    private let searchSubject = BehaviorSubject<String>(value: "")
+    private let dateSubject = PublishSubject<Date>()
+    private let hoverSubject = PublishSubject<Date?>()
+    private let keyboardModifiers = BehaviorSubject<NSEvent.ModifierFlags>(value: [])
+    private let enabledCalendars = BehaviorSubject<[String]>(value: [])
+
+    private let dateProvider = MockDateProvider()
+    private let settings = MockCalendarSettings()
+    private let scheduler = HistoricalScheduler()
+
+    private lazy var calendarService = MockCalendarServiceProvider(dateProvider: dateProvider)
+    private lazy var viewModel = CalendarViewModel(
+        searchObservable: searchSubject,
+        dateObservable: dateSubject,
+        hoverObservable: hoverSubject,
+        keyboardModifiers: keyboardModifiers,
+        enabledCalendars: enabledCalendars,
+        calendarService: calendarService,
+        dateProvider: dateProvider,
+        settings: settings,
+        scheduler: scheduler
+    )
+
+    private var eventList: DateEvents?
+
+    init() {
+
+        let calendar = CalendarModel.make(id: "calendar", account: "Account", title: "Calendar", color: .blue)
+
+        calendarService.m_events = [
+            .make(start: .make(year: 2020, month: 12, day: 24), title: "Find outside leading margin", calendar: calendar),
+            .make(start: .make(year: 2020, month: 12, day: 25), title: "Find leading margin", calendar: calendar),
+            .make(start: .make(year: 2021, month: 1, day: 1), title: "Find first day", calendar: calendar),
+            .make(start: .make(year: 2021, month: 6, day: 15), title: "Find middle of year", calendar: calendar),
+            .make(start: .make(year: 2021, month: 12, day: 31), title: "Find last day", calendar: calendar),
+            .make(start: .make(year: 2022, month: 2, day: 1), title: "Find trailing margin", calendar: calendar),
+            .make(start: .make(year: 2022, month: 2, day: 2), title: "Find outside trailing margin", calendar: calendar),
+        ]
+
+        viewModel.eventListObservable
+            .bind { [weak self] in
+                self?.eventList = $0
+            }
+            .disposed(by: disposeBag)
+
+        scheduler.advance(.seconds(1))
+    }
+
+    @Test func testSearch_returnsMatchesFromFocusedYearAndFetchMargins() {
+
+        dateSubject.onNext(.make(year: 2021, month: 1, day: 1))
+        searchSubject.onNext("Find")
+
+        #expect(eventList?.date == .distantPast)
+        #expect(eventList?.events.map(\.title) == [
+            "Find leading margin",
+            "Find first day",
+            "Find middle of year",
+            "Find last day",
+            "Find trailing margin",
+        ])
+    }
+
+    @Test func testSearch_limitsResultsToTwelveEvents() {
+
+        let calendar = CalendarModel.make(id: "calendar", account: "Account", title: "Calendar", color: .blue)
+        calendarService.m_events = (1...13).map {
+            .make(
+                start: .make(year: 2021, month: $0, day: 1),
+                title: "Find \($0)",
+                calendar: calendar
+            )
+        }
+
+        dateSubject.onNext(.make(year: 2021, month: 1, day: 1))
+        searchSubject.onNext("Find")
+
+        #expect(eventList?.events.map(\.title) == (2...13).map { "Find \($0)" })
+    }
+
+    @Test func testSearch_resultsAreUnaffectedByDateAndHoverChanges() throws {
+
+        var calls = 0
+
+        viewModel.eventListObservable
+            .void()
+            .bind { calls += 1 }
+            .disposed(by: disposeBag)
+
+        #expect(calls == 0)
+
+        dateSubject.onNext(.make(year: 2021, month: 1, day: 1))
+        searchSubject.onNext("Find")
+
+        #expect(calls == 2)
+
+        let searchResults = try #require(eventList)
+
+        #expect(searchResults.events.count == 5)
+
+        dateSubject.onNext(.make(year: 2021, month: 6, day: 1))
+        hoverSubject.onNext(.make(year: 2021, month: 6, day: 15))
+        hoverSubject.onNext(nil)
+
+        #expect(eventList == searchResults)
+        #expect(calls == 2)
+    }
+}

--- a/CalendrTests/CalendarViewModelTests.swift
+++ b/CalendrTests/CalendarViewModelTests.swift
@@ -564,7 +564,7 @@ class CalendarViewModelTests {
         var events: [EventModel]?
 
         viewModel
-            .focusedDateEventsObservable
+            .eventListObservable
             .bind { events = $0.events }
             .disposed(by: disposeBag)
 
@@ -592,7 +592,7 @@ class CalendarViewModelTests {
         var events: [EventModel]?
 
         viewModel
-            .focusedDateEventsObservable
+            .eventListObservable
             .bind { events = $0.events }
             .disposed(by: disposeBag)
 
@@ -763,7 +763,7 @@ class CalendarViewModelTests {
         var events: [EventModel]?
 
         viewModel
-            .focusedDateEventsObservable
+            .eventListObservable
             .bind { events = $0.events }
             .disposed(by: disposeBag)
 
@@ -794,7 +794,7 @@ class CalendarViewModelTests {
         var events: [EventModel]?
 
         viewModel
-            .focusedDateEventsObservable
+            .eventListObservable
             .bind { events = $0.events }
             .disposed(by: disposeBag)
 
@@ -830,7 +830,7 @@ class CalendarViewModelTests {
         var events: [EventModel]?
 
         viewModel
-            .focusedDateEventsObservable
+            .eventListObservable
             .bind { events = $0.events }
             .disposed(by: disposeBag)
 
@@ -908,11 +908,13 @@ class CalendarViewModelTests {
         dateSubject.onNext(.make(year: 2021, month: 1, day: 1))
         dateSubject.onNext(.make(year: 2021, month: 1, day: 2))
         dateSubject.onNext(.make(year: 2021, month: 2, day: 1))
+        dateSubject.onNext(.make(year: 2022, month: 1, day: 1))
 
-        #expect(ranges == [
-            [.make(year: 2020, month: 12, day: 27), .make(year: 2021, month: 2, day: 6, at: .end)], // calendar
-            [.make(year: 2021, month: 1, day: 31), .make(year: 2021, month: 3, day: 13, at: .end)] // month change
-        ])
+        #expect(ranges.count == 2)
+
+        // fetch range is year interval -7 days +1 month
+        #expect(ranges.first == [.make(year: 2020, month: 12, day: 25), .make(year: 2022, month: 2, day: 1, at: .end)]) // calendar
+        #expect(ranges.last == [.make(year: 2021, month: 12, day: 25), .make(year: 2023, month: 2, day: 1, at: .end)]) // year change
     }
 
     @Test func testServiceProviderEventsCalendars() {
@@ -926,13 +928,11 @@ class CalendarViewModelTests {
 
         calendarsSubject.onNext(["1", "2", "3"])
         dateSubject.onNext(.make(year: 2021, month: 1, day: 1))
-        dateSubject.onNext(.make(year: 2021, month: 2, day: 1))
         calendarsSubject.onNext(["1", "3"])
 
         #expect(calendars == [
-            ["1", "2", "3"], // calendar
-            ["1", "2", "3"], // month change
-            ["1", "3"] // calendar
+            ["1", "2", "3"],
+            ["1", "3"]
         ])
     }
 


### PR DESCRIPTION
Expand data fetching to the entire year and display the filtered events in the event list when the user is searching.

Close #714 