### PR TITLE
Add event deletion

### DIFF
--- a/Calendr/Assets/cs.lproj/Localizable.strings
+++ b/Calendr/Assets/cs.lproj/Localizable.strings
@@ -176,6 +176,13 @@
 "event.action.accept" = "Přijmout";
 "event.action.maybe" = "Možná";
 "event.action.decline" = "Odmítnout";
+"event.action.delete" = "Smazat";
+
+"event.delete.title" = "Smazat událost";
+"event.delete.message" = "Chcete smazat tento a všechny budoucí výskyty této události, nebo pouze vybraný výskyt?";
+"event.delete.this_event" = "Smazat pouze tuto událost";
+"event.delete.future_events" = "Smazat všechny budoucí události";
+"event.delete.cancel" = "Zrušit";
 
 "event_list.summary.agenda" = "Agenda";
 

--- a/Calendr/Assets/cs.lproj/Localizable.strings
+++ b/Calendr/Assets/cs.lproj/Localizable.strings
@@ -180,6 +180,7 @@
 
 "event.delete.title" = "Smazat událost";
 "event.delete.message" = "Chcete smazat tento a všechny budoucí výskyty této události, nebo pouze vybraný výskyt?";
+"event.delete.single_message" = "Opravdu chcete tuto událost smazat?";
 "event.delete.this_event" = "Smazat pouze tuto událost";
 "event.delete.future_events" = "Smazat všechny budoucí události";
 "event.delete.cancel" = "Zrušit";

--- a/Calendr/Assets/de.lproj/Localizable.strings
+++ b/Calendr/Assets/de.lproj/Localizable.strings
@@ -180,6 +180,7 @@
 
 //"event.delete.title" = "Delete Event";
 //"event.delete.message" = "Do you want to delete this and all future occurrences of this event, or only the selected occurrence?";
+//"event.delete.single_message" = "Are you sure you want to delete this event?";
 //"event.delete.this_event" = "Delete Only This Event";
 //"event.delete.future_events" = "Delete All Future Events";
 //"event.delete.cancel" = "Cancel";

--- a/Calendr/Assets/de.lproj/Localizable.strings
+++ b/Calendr/Assets/de.lproj/Localizable.strings
@@ -176,6 +176,13 @@
 "event.action.accept" = "Akzeptieren";
 "event.action.maybe" = "Vielleicht";
 "event.action.decline" = "Ablehnen";
+//"event.action.delete" = "Delete";
+
+//"event.delete.title" = "Delete Event";
+//"event.delete.message" = "Do you want to delete this and all future occurrences of this event, or only the selected occurrence?";
+//"event.delete.this_event" = "Delete Only This Event";
+//"event.delete.future_events" = "Delete All Future Events";
+//"event.delete.cancel" = "Cancel";
 
 "event_list.summary.agenda" = "Heute";
 

--- a/Calendr/Assets/el.lproj/Localizable.strings
+++ b/Calendr/Assets/el.lproj/Localizable.strings
@@ -180,6 +180,7 @@
 
 //"event.delete.title" = "Delete Event";
 //"event.delete.message" = "Do you want to delete this and all future occurrences of this event, or only the selected occurrence?";
+//"event.delete.single_message" = "Are you sure you want to delete this event?";
 //"event.delete.this_event" = "Delete Only This Event";
 //"event.delete.future_events" = "Delete All Future Events";
 //"event.delete.cancel" = "Cancel";

--- a/Calendr/Assets/el.lproj/Localizable.strings
+++ b/Calendr/Assets/el.lproj/Localizable.strings
@@ -176,6 +176,13 @@
 "event.action.accept" = "Αποδοχή";
 "event.action.maybe" = "Ίσως";
 "event.action.decline" = "Απορρίπτεται";
+//"event.action.delete" = "Delete";
+
+//"event.delete.title" = "Delete Event";
+//"event.delete.message" = "Do you want to delete this and all future occurrences of this event, or only the selected occurrence?";
+//"event.delete.this_event" = "Delete Only This Event";
+//"event.delete.future_events" = "Delete All Future Events";
+//"event.delete.cancel" = "Cancel";
 
 "event_list.summary.agenda" = "Σήμερα";
 

--- a/Calendr/Assets/en.lproj/Localizable.strings
+++ b/Calendr/Assets/en.lproj/Localizable.strings
@@ -176,6 +176,13 @@
 "event.action.accept" = "Accept";
 "event.action.maybe" = "Maybe";
 "event.action.decline" = "Decline";
+"event.action.delete" = "Delete";
+
+"event.delete.title" = "Delete Event";
+"event.delete.message" = "Do you want to delete this and all future occurrences of this event, or only the selected occurrence?";
+"event.delete.this_event" = "Delete Only This Event";
+"event.delete.future_events" = "Delete All Future Events";
+"event.delete.cancel" = "Cancel";
 
 "event_list.summary.agenda" = "Agenda";
 

--- a/Calendr/Assets/en.lproj/Localizable.strings
+++ b/Calendr/Assets/en.lproj/Localizable.strings
@@ -180,6 +180,7 @@
 
 "event.delete.title" = "Delete Event";
 "event.delete.message" = "Do you want to delete this and all future occurrences of this event, or only the selected occurrence?";
+"event.delete.single_message" = "Are you sure you want to delete this event?";
 "event.delete.this_event" = "Delete Only This Event";
 "event.delete.future_events" = "Delete All Future Events";
 "event.delete.cancel" = "Cancel";

--- a/Calendr/Assets/es.lproj/Localizable.strings
+++ b/Calendr/Assets/es.lproj/Localizable.strings
@@ -180,6 +180,7 @@
 
 //"event.delete.title" = "Delete Event";
 //"event.delete.message" = "Do you want to delete this and all future occurrences of this event, or only the selected occurrence?";
+//"event.delete.single_message" = "Are you sure you want to delete this event?";
 //"event.delete.this_event" = "Delete Only This Event";
 //"event.delete.future_events" = "Delete All Future Events";
 //"event.delete.cancel" = "Cancel";

--- a/Calendr/Assets/es.lproj/Localizable.strings
+++ b/Calendr/Assets/es.lproj/Localizable.strings
@@ -176,6 +176,13 @@
 "event.action.accept" = "Aceptar";
 "event.action.maybe" = "Quizá";
 "event.action.decline" = "Rechazar";
+//"event.action.delete" = "Delete";
+
+//"event.delete.title" = "Delete Event";
+//"event.delete.message" = "Do you want to delete this and all future occurrences of this event, or only the selected occurrence?";
+//"event.delete.this_event" = "Delete Only This Event";
+//"event.delete.future_events" = "Delete All Future Events";
+//"event.delete.cancel" = "Cancel";
 
 "event_list.summary.agenda" = "Agenda";
 

--- a/Calendr/Assets/fr.lproj/Localizable.strings
+++ b/Calendr/Assets/fr.lproj/Localizable.strings
@@ -180,6 +180,7 @@
 
 //"event.delete.title" = "Delete Event";
 //"event.delete.message" = "Do you want to delete this and all future occurrences of this event, or only the selected occurrence?";
+//"event.delete.single_message" = "Are you sure you want to delete this event?";
 //"event.delete.this_event" = "Delete Only This Event";
 //"event.delete.future_events" = "Delete All Future Events";
 //"event.delete.cancel" = "Cancel";

--- a/Calendr/Assets/fr.lproj/Localizable.strings
+++ b/Calendr/Assets/fr.lproj/Localizable.strings
@@ -176,6 +176,13 @@
 "event.action.accept" = "Accepter";
 "event.action.maybe" = "Peut-être";
 "event.action.decline" = "Refuser";
+//"event.action.delete" = "Delete";
+
+//"event.delete.title" = "Delete Event";
+//"event.delete.message" = "Do you want to delete this and all future occurrences of this event, or only the selected occurrence?";
+//"event.delete.this_event" = "Delete Only This Event";
+//"event.delete.future_events" = "Delete All Future Events";
+//"event.delete.cancel" = "Cancel";
 
 "event_list.summary.agenda" = "Aujourd'hui";
 

--- a/Calendr/Assets/he.lproj/Localizable.strings
+++ b/Calendr/Assets/he.lproj/Localizable.strings
@@ -176,6 +176,13 @@
 "event.action.accept" = "אשר";
 "event.action.maybe" = "אולי";
 "event.action.decline" = "דחה";
+//"event.action.delete" = "Delete";
+
+//"event.delete.title" = "Delete Event";
+//"event.delete.message" = "Do you want to delete this and all future occurrences of this event, or only the selected occurrence?";
+//"event.delete.this_event" = "Delete Only This Event";
+//"event.delete.future_events" = "Delete All Future Events";
+//"event.delete.cancel" = "Cancel";
 
 "event_list.summary.agenda" = "היום";
 

--- a/Calendr/Assets/he.lproj/Localizable.strings
+++ b/Calendr/Assets/he.lproj/Localizable.strings
@@ -180,6 +180,7 @@
 
 //"event.delete.title" = "Delete Event";
 //"event.delete.message" = "Do you want to delete this and all future occurrences of this event, or only the selected occurrence?";
+//"event.delete.single_message" = "Are you sure you want to delete this event?";
 //"event.delete.this_event" = "Delete Only This Event";
 //"event.delete.future_events" = "Delete All Future Events";
 //"event.delete.cancel" = "Cancel";

--- a/Calendr/Assets/it.lproj/Localizable.strings
+++ b/Calendr/Assets/it.lproj/Localizable.strings
@@ -177,6 +177,13 @@
 "event.action.accept" = "Accetta";
 "event.action.maybe" = "Forse";
 "event.action.decline" = "Rifiuta";
+//"event.action.delete" = "Delete";
+
+//"event.delete.title" = "Delete Event";
+//"event.delete.message" = "Do you want to delete this and all future occurrences of this event, or only the selected occurrence?";
+//"event.delete.this_event" = "Delete Only This Event";
+//"event.delete.future_events" = "Delete All Future Events";
+//"event.delete.cancel" = "Cancel";
 
 "event_list.summary.agenda" = "Oggi";
 

--- a/Calendr/Assets/it.lproj/Localizable.strings
+++ b/Calendr/Assets/it.lproj/Localizable.strings
@@ -181,6 +181,7 @@
 
 //"event.delete.title" = "Delete Event";
 //"event.delete.message" = "Do you want to delete this and all future occurrences of this event, or only the selected occurrence?";
+//"event.delete.single_message" = "Are you sure you want to delete this event?";
 //"event.delete.this_event" = "Delete Only This Event";
 //"event.delete.future_events" = "Delete All Future Events";
 //"event.delete.cancel" = "Cancel";

--- a/Calendr/Assets/ja.lproj/Localizable.strings
+++ b/Calendr/Assets/ja.lproj/Localizable.strings
@@ -180,6 +180,7 @@
 
 //"event.delete.title" = "Delete Event";
 //"event.delete.message" = "Do you want to delete this and all future occurrences of this event, or only the selected occurrence?";
+//"event.delete.single_message" = "Are you sure you want to delete this event?";
 //"event.delete.this_event" = "Delete Only This Event";
 //"event.delete.future_events" = "Delete All Future Events";
 //"event.delete.cancel" = "Cancel";

--- a/Calendr/Assets/ja.lproj/Localizable.strings
+++ b/Calendr/Assets/ja.lproj/Localizable.strings
@@ -176,6 +176,13 @@
 "event.action.accept" = "承諾する";
 "event.action.maybe" = "仮承諾";
 "event.action.decline" = "辞退する";
+//"event.action.delete" = "Delete";
+
+//"event.delete.title" = "Delete Event";
+//"event.delete.message" = "Do you want to delete this and all future occurrences of this event, or only the selected occurrence?";
+//"event.delete.this_event" = "Delete Only This Event";
+//"event.delete.future_events" = "Delete All Future Events";
+//"event.delete.cancel" = "Cancel";
 
 "event_list.summary.agenda" = "今日";
 

--- a/Calendr/Assets/ko.lproj/Localizable.strings
+++ b/Calendr/Assets/ko.lproj/Localizable.strings
@@ -176,6 +176,13 @@
 "event.action.accept" = "수락";
 "event.action.maybe" = "미정";
 "event.action.decline" = "거절";
+//"event.action.delete" = "Delete";
+
+//"event.delete.title" = "Delete Event";
+//"event.delete.message" = "Do you want to delete this and all future occurrences of this event, or only the selected occurrence?";
+//"event.delete.this_event" = "Delete Only This Event";
+//"event.delete.future_events" = "Delete All Future Events";
+//"event.delete.cancel" = "Cancel";
 
 "event_list.summary.agenda" = "오늘";
 

--- a/Calendr/Assets/ko.lproj/Localizable.strings
+++ b/Calendr/Assets/ko.lproj/Localizable.strings
@@ -180,6 +180,7 @@
 
 //"event.delete.title" = "Delete Event";
 //"event.delete.message" = "Do you want to delete this and all future occurrences of this event, or only the selected occurrence?";
+//"event.delete.single_message" = "Are you sure you want to delete this event?";
 //"event.delete.this_event" = "Delete Only This Event";
 //"event.delete.future_events" = "Delete All Future Events";
 //"event.delete.cancel" = "Cancel";

--- a/Calendr/Assets/nl.lproj/Localizable.strings
+++ b/Calendr/Assets/nl.lproj/Localizable.strings
@@ -178,6 +178,7 @@
 
 //"event.delete.title" = "Delete Event";
 //"event.delete.message" = "Do you want to delete this and all future occurrences of this event, or only the selected occurrence?";
+//"event.delete.single_message" = "Are you sure you want to delete this event?";
 //"event.delete.this_event" = "Delete Only This Event";
 //"event.delete.future_events" = "Delete All Future Events";
 //"event.delete.cancel" = "Cancel";

--- a/Calendr/Assets/nl.lproj/Localizable.strings
+++ b/Calendr/Assets/nl.lproj/Localizable.strings
@@ -174,6 +174,13 @@
 "event.action.accept" = "Accepteren";
 "event.action.maybe" = "Misschien";
 "event.action.decline" = "Afwijzen";
+//"event.action.delete" = "Delete";
+
+//"event.delete.title" = "Delete Event";
+//"event.delete.message" = "Do you want to delete this and all future occurrences of this event, or only the selected occurrence?";
+//"event.delete.this_event" = "Delete Only This Event";
+//"event.delete.future_events" = "Delete All Future Events";
+//"event.delete.cancel" = "Cancel";
 
 "event_list.summary.agenda" = "Vandaag";
 

--- a/Calendr/Assets/pl.lproj/Localizable.strings
+++ b/Calendr/Assets/pl.lproj/Localizable.strings
@@ -180,6 +180,7 @@
 
 //"event.delete.title" = "Delete Event";
 //"event.delete.message" = "Do you want to delete this and all future occurrences of this event, or only the selected occurrence?";
+//"event.delete.single_message" = "Are you sure you want to delete this event?";
 //"event.delete.this_event" = "Delete Only This Event";
 //"event.delete.future_events" = "Delete All Future Events";
 //"event.delete.cancel" = "Cancel";

--- a/Calendr/Assets/pl.lproj/Localizable.strings
+++ b/Calendr/Assets/pl.lproj/Localizable.strings
@@ -176,6 +176,13 @@
 "event.action.accept" = "Akceptuj";
 "event.action.maybe" = "Może";
 "event.action.decline" = "Odrzuć";
+//"event.action.delete" = "Delete";
+
+//"event.delete.title" = "Delete Event";
+//"event.delete.message" = "Do you want to delete this and all future occurrences of this event, or only the selected occurrence?";
+//"event.delete.this_event" = "Delete Only This Event";
+//"event.delete.future_events" = "Delete All Future Events";
+//"event.delete.cancel" = "Cancel";
 
 "event_list.summary.agenda" = "Dzisiaj";
 

--- a/Calendr/Assets/pt.lproj/Localizable.strings
+++ b/Calendr/Assets/pt.lproj/Localizable.strings
@@ -176,6 +176,13 @@
 "event.action.accept" = "Aceitar";
 "event.action.maybe" = "Talvez";
 "event.action.decline" = "Recusar";
+//"event.action.delete" = "Delete";
+
+//"event.delete.title" = "Delete Event";
+//"event.delete.message" = "Do you want to delete this and all future occurrences of this event, or only the selected occurrence?";
+//"event.delete.this_event" = "Delete Only This Event";
+//"event.delete.future_events" = "Delete All Future Events";
+//"event.delete.cancel" = "Cancel";
 
 "event_list.summary.agenda" = "Agenda";
 

--- a/Calendr/Assets/pt.lproj/Localizable.strings
+++ b/Calendr/Assets/pt.lproj/Localizable.strings
@@ -180,6 +180,7 @@
 
 //"event.delete.title" = "Delete Event";
 //"event.delete.message" = "Do you want to delete this and all future occurrences of this event, or only the selected occurrence?";
+//"event.delete.single_message" = "Are you sure you want to delete this event?";
 //"event.delete.this_event" = "Delete Only This Event";
 //"event.delete.future_events" = "Delete All Future Events";
 //"event.delete.cancel" = "Cancel";

--- a/Calendr/Assets/ru.lproj/Localizable.strings
+++ b/Calendr/Assets/ru.lproj/Localizable.strings
@@ -178,6 +178,13 @@
 "event.action.accept" = "Принять";
 "event.action.maybe" = "Возможно";
 "event.action.decline" = "Отклонить";
+//"event.action.delete" = "Delete";
+
+//"event.delete.title" = "Delete Event";
+//"event.delete.message" = "Do you want to delete this and all future occurrences of this event, or only the selected occurrence?";
+//"event.delete.this_event" = "Delete Only This Event";
+//"event.delete.future_events" = "Delete All Future Events";
+//"event.delete.cancel" = "Cancel";
 
 "event_list.summary.agenda" = "Сегодня";
 

--- a/Calendr/Assets/ru.lproj/Localizable.strings
+++ b/Calendr/Assets/ru.lproj/Localizable.strings
@@ -182,6 +182,7 @@
 
 //"event.delete.title" = "Delete Event";
 //"event.delete.message" = "Do you want to delete this and all future occurrences of this event, or only the selected occurrence?";
+//"event.delete.single_message" = "Are you sure you want to delete this event?";
 //"event.delete.this_event" = "Delete Only This Event";
 //"event.delete.future_events" = "Delete All Future Events";
 //"event.delete.cancel" = "Cancel";

--- a/Calendr/Assets/sk.lproj/Localizable.strings
+++ b/Calendr/Assets/sk.lproj/Localizable.strings
@@ -180,6 +180,7 @@
 
 //"event.delete.title" = "Delete Event";
 //"event.delete.message" = "Do you want to delete this and all future occurrences of this event, or only the selected occurrence?";
+//"event.delete.single_message" = "Are you sure you want to delete this event?";
 //"event.delete.this_event" = "Delete Only This Event";
 //"event.delete.future_events" = "Delete All Future Events";
 //"event.delete.cancel" = "Cancel";

--- a/Calendr/Assets/sk.lproj/Localizable.strings
+++ b/Calendr/Assets/sk.lproj/Localizable.strings
@@ -176,6 +176,13 @@
 "event.action.accept" = "Prijať";
 "event.action.maybe" = "Možno";
 "event.action.decline" = "Odmietnuť";
+//"event.action.delete" = "Delete";
+
+//"event.delete.title" = "Delete Event";
+//"event.delete.message" = "Do you want to delete this and all future occurrences of this event, or only the selected occurrence?";
+//"event.delete.this_event" = "Delete Only This Event";
+//"event.delete.future_events" = "Delete All Future Events";
+//"event.delete.cancel" = "Cancel";
 
 "event_list.summary.agenda" = "Dnes";
 

--- a/Calendr/Assets/sq.lproj/Localizable.strings
+++ b/Calendr/Assets/sq.lproj/Localizable.strings
@@ -180,6 +180,7 @@
 
 //"event.delete.title" = "Delete Event";
 //"event.delete.message" = "Do you want to delete this and all future occurrences of this event, or only the selected occurrence?";
+//"event.delete.single_message" = "Are you sure you want to delete this event?";
 //"event.delete.this_event" = "Delete Only This Event";
 //"event.delete.future_events" = "Delete All Future Events";
 //"event.delete.cancel" = "Cancel";

--- a/Calendr/Assets/sq.lproj/Localizable.strings
+++ b/Calendr/Assets/sq.lproj/Localizable.strings
@@ -176,6 +176,13 @@
 "event.action.accept" = "Pranoje";
 "event.action.maybe" = "Ndoshta";
 "event.action.decline" = "Rënia";
+//"event.action.delete" = "Delete";
+
+//"event.delete.title" = "Delete Event";
+//"event.delete.message" = "Do you want to delete this and all future occurrences of this event, or only the selected occurrence?";
+//"event.delete.this_event" = "Delete Only This Event";
+//"event.delete.future_events" = "Delete All Future Events";
+//"event.delete.cancel" = "Cancel";
 
 "event_list.summary.agenda" = "Sot";
 

--- a/Calendr/Assets/sv.lproj/Localizable.strings
+++ b/Calendr/Assets/sv.lproj/Localizable.strings
@@ -180,6 +180,7 @@
 
 //"event.delete.title" = "Delete Event";
 //"event.delete.message" = "Do you want to delete this and all future occurrences of this event, or only the selected occurrence?";
+//"event.delete.single_message" = "Are you sure you want to delete this event?";
 //"event.delete.this_event" = "Delete Only This Event";
 //"event.delete.future_events" = "Delete All Future Events";
 //"event.delete.cancel" = "Cancel";

--- a/Calendr/Assets/sv.lproj/Localizable.strings
+++ b/Calendr/Assets/sv.lproj/Localizable.strings
@@ -176,6 +176,13 @@
 "event.action.accept" = "Tacka ja";
 "event.action.maybe" = "Kanske";
 "event.action.decline" = "Avböj";
+//"event.action.delete" = "Delete";
+
+//"event.delete.title" = "Delete Event";
+//"event.delete.message" = "Do you want to delete this and all future occurrences of this event, or only the selected occurrence?";
+//"event.delete.this_event" = "Delete Only This Event";
+//"event.delete.future_events" = "Delete All Future Events";
+//"event.delete.cancel" = "Cancel";
 
 "event_list.summary.agenda" = "Idag";
 

--- a/Calendr/Assets/tr.lproj/Localizable.strings
+++ b/Calendr/Assets/tr.lproj/Localizable.strings
@@ -180,6 +180,7 @@
 
 //"event.delete.title" = "Delete Event";
 //"event.delete.message" = "Do you want to delete this and all future occurrences of this event, or only the selected occurrence?";
+//"event.delete.single_message" = "Are you sure you want to delete this event?";
 //"event.delete.this_event" = "Delete Only This Event";
 //"event.delete.future_events" = "Delete All Future Events";
 //"event.delete.cancel" = "Cancel";

--- a/Calendr/Assets/tr.lproj/Localizable.strings
+++ b/Calendr/Assets/tr.lproj/Localizable.strings
@@ -176,6 +176,13 @@
 "event.action.accept" = "Kabul et";
 "event.action.maybe" = "Belki";
 "event.action.decline" = "Reddet";
+//"event.action.delete" = "Delete";
+
+//"event.delete.title" = "Delete Event";
+//"event.delete.message" = "Do you want to delete this and all future occurrences of this event, or only the selected occurrence?";
+//"event.delete.this_event" = "Delete Only This Event";
+//"event.delete.future_events" = "Delete All Future Events";
+//"event.delete.cancel" = "Cancel";
 
 "event_list.summary.agenda" = "Bugün";
 

--- a/Calendr/Assets/uk.lproj/Localizable.strings
+++ b/Calendr/Assets/uk.lproj/Localizable.strings
@@ -180,6 +180,7 @@
 
 //"event.delete.title" = "Delete Event";
 //"event.delete.message" = "Do you want to delete this and all future occurrences of this event, or only the selected occurrence?";
+//"event.delete.single_message" = "Are you sure you want to delete this event?";
 //"event.delete.this_event" = "Delete Only This Event";
 //"event.delete.future_events" = "Delete All Future Events";
 //"event.delete.cancel" = "Cancel";

--- a/Calendr/Assets/uk.lproj/Localizable.strings
+++ b/Calendr/Assets/uk.lproj/Localizable.strings
@@ -176,6 +176,13 @@
 "event.action.accept" = "Прийняти";
 "event.action.maybe" = "Можливо";
 "event.action.decline" = "Відхилити";
+//"event.action.delete" = "Delete";
+
+//"event.delete.title" = "Delete Event";
+//"event.delete.message" = "Do you want to delete this and all future occurrences of this event, or only the selected occurrence?";
+//"event.delete.this_event" = "Delete Only This Event";
+//"event.delete.future_events" = "Delete All Future Events";
+//"event.delete.cancel" = "Cancel";
 
 "event_list.summary.agenda" = "Сьогодні";
 

--- a/Calendr/Assets/zh-Hans.lproj/Localizable.strings
+++ b/Calendr/Assets/zh-Hans.lproj/Localizable.strings
@@ -176,6 +176,13 @@
 "event.action.accept" = "接受";
 "event.action.maybe" = "也许";
 "event.action.decline" = "拒绝";
+//"event.action.delete" = "Delete";
+
+//"event.delete.title" = "Delete Event";
+//"event.delete.message" = "Do you want to delete this and all future occurrences of this event, or only the selected occurrence?";
+//"event.delete.this_event" = "Delete Only This Event";
+//"event.delete.future_events" = "Delete All Future Events";
+//"event.delete.cancel" = "Cancel";
 
 "event_list.summary.agenda" = "今日";
 

--- a/Calendr/Assets/zh-Hans.lproj/Localizable.strings
+++ b/Calendr/Assets/zh-Hans.lproj/Localizable.strings
@@ -180,6 +180,7 @@
 
 //"event.delete.title" = "Delete Event";
 //"event.delete.message" = "Do you want to delete this and all future occurrences of this event, or only the selected occurrence?";
+//"event.delete.single_message" = "Are you sure you want to delete this event?";
 //"event.delete.this_event" = "Delete Only This Event";
 //"event.delete.future_events" = "Delete All Future Events";
 //"event.delete.cancel" = "Cancel";

--- a/Calendr/Assets/zh-Hant-TW.lproj/Localizable.strings
+++ b/Calendr/Assets/zh-Hant-TW.lproj/Localizable.strings
@@ -176,6 +176,13 @@
 "event.action.accept" = "接受";
 "event.action.maybe" = "可能";
 "event.action.decline" = "拒絕";
+//"event.action.delete" = "Delete";
+
+//"event.delete.title" = "Delete Event";
+//"event.delete.message" = "Do you want to delete this and all future occurrences of this event, or only the selected occurrence?";
+//"event.delete.this_event" = "Delete Only This Event";
+//"event.delete.future_events" = "Delete All Future Events";
+//"event.delete.cancel" = "Cancel";
 
 "event_list.summary.agenda" = "今天";
 

--- a/Calendr/Assets/zh-Hant-TW.lproj/Localizable.strings
+++ b/Calendr/Assets/zh-Hant-TW.lproj/Localizable.strings
@@ -180,6 +180,7 @@
 
 //"event.delete.title" = "Delete Event";
 //"event.delete.message" = "Do you want to delete this and all future occurrences of this event, or only the selected occurrence?";
+//"event.delete.single_message" = "Are you sure you want to delete this event?";
 //"event.delete.this_event" = "Delete Only This Event";
 //"event.delete.future_events" = "Delete All Future Events";
 //"event.delete.cancel" = "Cancel";

--- a/Calendr/Constants/Icons.swift
+++ b/Calendr/Constants/Icons.swift
@@ -65,6 +65,7 @@ enum Icons {
         static let video = NSImage(systemName: "video")
         static let video_fill = NSImage(systemName: "video.fill")
         static let skip = NSImage(systemName: "forward")
+        static let delete = NSImage(systemName: "trash")
         static let recurrence = NSImage(systemName: "repeat")
         static let flagged = NSImage(systemName: "flag.fill")
     }

--- a/Calendr/Constants/Strings.generated.swift
+++ b/Calendr/Constants/Strings.generated.swift
@@ -115,6 +115,8 @@ internal enum Strings {
       internal static let futureEvents = Strings.tr("Localizable", "event.delete.future_events", fallback: "Delete All Future Events")
       /// Do you want to delete this and all future occurrences of this event, or only the selected occurrence?
       internal static let message = Strings.tr("Localizable", "event.delete.message", fallback: "Do you want to delete this and all future occurrences of this event, or only the selected occurrence?")
+      /// Are you sure you want to delete this event?
+      internal static let singleMessage = Strings.tr("Localizable", "event.delete.single_message", fallback: "Are you sure you want to delete this event?")
       /// Delete Only This Event
       internal static let thisEvent = Strings.tr("Localizable", "event.delete.this_event", fallback: "Delete Only This Event")
       /// Delete Event

--- a/Calendr/Constants/Strings.generated.swift
+++ b/Calendr/Constants/Strings.generated.swift
@@ -97,6 +97,8 @@ internal enum Strings {
       internal static let accept = Strings.tr("Localizable", "event.action.accept", fallback: "Accept")
       /// Decline
       internal static let decline = Strings.tr("Localizable", "event.action.decline", fallback: "Decline")
+      /// Delete
+      internal static let delete = Strings.tr("Localizable", "event.action.delete", fallback: "Delete")
       /// Join
       internal static let join = Strings.tr("Localizable", "event.action.join", fallback: "Join")
       /// Maybe
@@ -105,6 +107,18 @@ internal enum Strings {
       internal static let `open` = Strings.tr("Localizable", "event.action.open", fallback: "Open")
       /// Skip
       internal static let skip = Strings.tr("Localizable", "event.action.skip", fallback: "Skip")
+    }
+    internal enum Delete {
+      /// Cancel
+      internal static let cancel = Strings.tr("Localizable", "event.delete.cancel", fallback: "Cancel")
+      /// Delete All Future Events
+      internal static let futureEvents = Strings.tr("Localizable", "event.delete.future_events", fallback: "Delete All Future Events")
+      /// Do you want to delete this and all future occurrences of this event, or only the selected occurrence?
+      internal static let message = Strings.tr("Localizable", "event.delete.message", fallback: "Do you want to delete this and all future occurrences of this event, or only the selected occurrence?")
+      /// Delete Only This Event
+      internal static let thisEvent = Strings.tr("Localizable", "event.delete.this_event", fallback: "Delete Only This Event")
+      /// Delete Event
+      internal static let title = Strings.tr("Localizable", "event.delete.title", fallback: "Delete Event")
     }
     internal enum Details {
       internal enum Participant {

--- a/Calendr/Events/ContextMenu/EventOptionsViewModel.swift
+++ b/Calendr/Events/ContextMenu/EventOptionsViewModel.swift
@@ -105,17 +105,11 @@ class EventOptionsViewModel: BaseContextMenuViewModel<EventAction> {
     }
 
     private func deleteEvent() -> Completable {
-        let scope: EventDeletionScope
-
-        if event.hasRecurrenceRules {
-            guard let confirmedScope = deletionConfirmation.confirmDeletion() else {
-                return .empty()
-            }
-            scope = confirmedScope
-        } else {
-            scope = .thisEvent
+        guard let confirmedScope = deletionConfirmation.confirmDeletion(isRecurring: event.hasRecurrenceRules) else {
+            return .empty()
         }
 
+        let scope = event.hasRecurrenceRules ? confirmedScope : .thisEvent
         return calendarService.deleteEvent(id: event.id, date: event.start, scope: scope)
     }
 }
@@ -183,27 +177,35 @@ extension EventAction: ContextMenuAction {
 }
 
 protocol EventDeletionConfirming {
-    func confirmDeletion() -> EventDeletionScope?
+    func confirmDeletion(isRecurring: Bool) -> EventDeletionScope?
 }
 
 final class EventDeletionConfirmation: EventDeletionConfirming {
 
-    func confirmDeletion() -> EventDeletionScope? {
+    func confirmDeletion(isRecurring: Bool) -> EventDeletionScope? {
         let alert = NSAlert()
         alert.alertStyle = .warning
         alert.messageText = Strings.Event.Delete.title
-        alert.informativeText = Strings.Event.Delete.message
-        alert.addButton(withTitle: Strings.Event.Delete.thisEvent)
-        alert.addButton(withTitle: Strings.Event.Delete.futureEvents)
-        alert.addButton(withTitle: Strings.Event.Delete.cancel)
-        alert.buttons[1].hasDestructiveAction = true
-        alert.buttons[2].keyEquivalent = "\u{1b}"
 
-        return switch alert.runModal() {
-            case .alertFirstButtonReturn: .thisEvent
-            case .alertSecondButtonReturn: .futureEvents
-            default: nil
+        if isRecurring {
+            alert.informativeText = Strings.Event.Delete.message
+            alert.addButton(withTitle: Strings.Event.Delete.thisEvent)
+            alert.addButton(withTitle: Strings.Event.Delete.futureEvents)
+            alert.addButton(withTitle: Strings.Event.Delete.cancel)
+            alert.buttons[1].hasDestructiveAction = true
+            alert.buttons[2].keyEquivalent = "\u{1b}"
+        } else {
+            alert.informativeText = Strings.Event.Delete.singleMessage
+            alert.addButton(withTitle: Strings.Event.Action.delete)
+            alert.addButton(withTitle: Strings.Event.Delete.cancel)
+            alert.buttons[0].hasDestructiveAction = true
+            alert.buttons[1].keyEquivalent = "\u{1b}"
         }
+
+        return switch (isRecurring, alert.runModal()) {
+        case (_, .alertFirstButtonReturn): .thisEvent
+        case (true, .alertSecondButtonReturn): .futureEvents
+        default: nil
         }
     }
 }

--- a/Calendr/Events/ContextMenu/EventOptionsViewModel.swift
+++ b/Calendr/Events/ContextMenu/EventOptionsViewModel.swift
@@ -13,6 +13,7 @@ enum EventAction: Equatable {
     case link(EventLink, isInProgress: Bool)
     case skip
     case status(EventStatusAction)
+    case delete
 }
 
 enum EventStatusAction: Equatable {
@@ -27,6 +28,7 @@ class EventOptionsViewModel: BaseContextMenuViewModel<EventAction> {
     private let dateProvider: DateProviding
     private let calendarService: CalendarServiceProviding
     private let workspace: WorkspaceServiceProviding
+    private let deletionConfirmation: EventDeletionConfirming
 
     init?(
         event: EventModel,
@@ -34,12 +36,14 @@ class EventOptionsViewModel: BaseContextMenuViewModel<EventAction> {
         calendarService: CalendarServiceProviding,
         workspace: WorkspaceServiceProviding,
         source: ContextMenuSource,
-        callback: AnyObserver<EventAction>
+        callback: AnyObserver<EventAction>,
+        deletionConfirmation: EventDeletionConfirming = EventDeletionConfirmation()
     ) {
         self.event = event
         self.dateProvider = dateProvider
         self.calendarService = calendarService
         self.workspace = workspace
+        self.deletionConfirmation = deletionConfirmation
 
         super.init(callback: callback)
 
@@ -71,6 +75,11 @@ class EventOptionsViewModel: BaseContextMenuViewModel<EventAction> {
             }
         }
 
+        if source ~= .calendar, event.type.isEvent, event.calendar.allowsContentModifications {
+            addSeparator()
+            addItem(.delete)
+        }
+
         guard !items.isEmpty else { return nil }
     }
 
@@ -85,12 +94,29 @@ class EventOptionsViewModel: BaseContextMenuViewModel<EventAction> {
             break // handled by callback
         case .status(let action):
             return changeEventStatus(to: action.status)
+        case .delete:
+            return deleteEvent()
         }
         return .empty()
     }
 
     private func changeEventStatus(to status: EventStatus) -> Completable {
         calendarService.changeEventStatus(id: event.id, date: event.start, to: status)
+    }
+
+    private func deleteEvent() -> Completable {
+        let scope: EventDeletionScope
+
+        if event.hasRecurrenceRules {
+            guard let confirmedScope = deletionConfirmation.confirmDeletion() else {
+                return .empty()
+            }
+            scope = confirmedScope
+        } else {
+            scope = .thisEvent
+        }
+
+        return calendarService.deleteEvent(id: event.id, date: event.start, scope: scope)
     }
 }
 
@@ -131,6 +157,8 @@ extension EventAction: ContextMenuAction {
             return Icons.EventStatus.maybe.with(color: .systemOrange)
         case .status(.decline):
             return Icons.EventStatus.declined.with(color: .systemRed)
+        case .delete:
+            return Icons.Event.delete
         }
     }
 
@@ -148,6 +176,33 @@ extension EventAction: ContextMenuAction {
             return Strings.Event.Action.maybe
         case .status(.decline):
             return Strings.Event.Action.decline
+        case .delete:
+            return Strings.Event.Action.delete
+        }
+    }
+}
+
+protocol EventDeletionConfirming {
+    func confirmDeletion() -> EventDeletionScope?
+}
+
+final class EventDeletionConfirmation: EventDeletionConfirming {
+
+    func confirmDeletion() -> EventDeletionScope? {
+        let alert = NSAlert()
+        alert.alertStyle = .warning
+        alert.messageText = Strings.Event.Delete.title
+        alert.informativeText = Strings.Event.Delete.message
+        alert.addButton(withTitle: Strings.Event.Delete.thisEvent)
+        alert.addButton(withTitle: Strings.Event.Delete.futureEvents)
+        alert.addButton(withTitle: Strings.Event.Delete.cancel)
+        alert.buttons[1].hasDestructiveAction = true
+        alert.buttons[2].keyEquivalent = "\u{1b}"
+
+        switch alert.runModal() {
+        case .alertFirstButtonReturn: return .thisEvent
+        case .alertSecondButtonReturn: return .futureEvents
+        default: return nil
         }
     }
 }

--- a/Calendr/Events/ContextMenu/EventOptionsViewModel.swift
+++ b/Calendr/Events/ContextMenu/EventOptionsViewModel.swift
@@ -199,10 +199,11 @@ final class EventDeletionConfirmation: EventDeletionConfirming {
         alert.buttons[1].hasDestructiveAction = true
         alert.buttons[2].keyEquivalent = "\u{1b}"
 
-        switch alert.runModal() {
-        case .alertFirstButtonReturn: return .thisEvent
-        case .alertSecondButtonReturn: return .futureEvents
-        default: return nil
+        return switch alert.runModal() {
+            case .alertFirstButtonReturn: .thisEvent
+            case .alertSecondButtonReturn: .futureEvents
+            default: nil
+        }
         }
     }
 }

--- a/Calendr/MenuBar/NextEventViewModel.swift
+++ b/Calendr/MenuBar/NextEventViewModel.swift
@@ -533,7 +533,8 @@ private func fakeEvent(
             account: .init(title: "", email: nil),
             title: "",
             color: color,
-            isSubscribed: false
+            isSubscribed: false,
+            allowsContentModifications: false
         ),
         participants: [],
         timeZone: nil,

--- a/Calendr/Mocks/Factories/CalendarModel+Factory.swift
+++ b/Calendr/Mocks/Factories/CalendarModel+Factory.swift
@@ -17,7 +17,8 @@ extension CalendarModel {
         email: String? = nil,
         title: String = "",
         color: NSColor = .clear,
-        isSubscribed: Bool = false
+        isSubscribed: Bool = false,
+        allowsContentModifications: Bool = true
     ) -> CalendarModel {
 
         .init(
@@ -25,7 +26,8 @@ extension CalendarModel {
             account: .init(title: account, email: email),
             title: title,
             color: color,
-            isSubscribed: isSubscribed
+            isSubscribed: isSubscribed,
+            allowsContentModifications: allowsContentModifications
         )
     }
 }

--- a/Calendr/Mocks/MockCalendarServiceProvider.swift
+++ b/Calendr/Mocks/MockCalendarServiceProvider.swift
@@ -25,6 +25,7 @@ typealias CreateEventArgs = (
     timeZone: TimeZone
 )
 typealias EventsArgs = (start: Date, end: Date, calendars: [String])
+typealias DeleteEventArgs = (id: String, date: Date, scope: EventDeletionScope)
 
 class MockCalendarServiceProvider: CalendarServiceProviding {
 
@@ -36,6 +37,7 @@ class MockCalendarServiceProvider: CalendarServiceProviding {
     let (spyCompleteReminderObservable, spyCompleteReminderObserver) = PublishSubject<Bool>.pipe()
     let (spyRescheduleReminderObservable, spyRescheduleReminderObserver) = PublishSubject<RescheduleReminderArgs>.pipe()
     let (spyChangeEventStatusObservable, spyChangeEventStatusObserver) = PublishSubject<EventStatus>.pipe()
+    let (spyDeleteEventObservable, spyDeleteEventObserver) = PublishSubject<DeleteEventArgs>.pipe()
 
     var didRequestAccess: (() -> Void)?
 
@@ -100,6 +102,11 @@ class MockCalendarServiceProvider: CalendarServiceProviding {
 
     func changeEventStatus(id: String, date: Date, to status: EventStatus) -> Completable {
         spyChangeEventStatusObserver.onNext(status)
+        return .empty()
+    }
+
+    func deleteEvent(id: String, date: Date, scope: EventDeletionScope) -> Completable {
+        spyDeleteEventObserver.onNext((id, date, scope))
         return .empty()
     }
 

--- a/Calendr/Models/CalendarModel.swift
+++ b/Calendr/Models/CalendarModel.swift
@@ -18,4 +18,5 @@ struct CalendarModel: Equatable {
     let title: String
     let color: NSColor
     let isSubscribed: Bool
+    let allowsContentModifications: Bool
 }

--- a/Calendr/Providers/CalendarServiceProvider.swift
+++ b/Calendr/Providers/CalendarServiceProvider.swift
@@ -14,6 +14,11 @@ enum CalendarEntityType {
     case reminder
 }
 
+enum EventDeletionScope: Equatable {
+    case thisEvent
+    case futureEvents
+}
+
 protocol CalendarServiceProviding {
 
     var changeObservable: Observable<Void> { get }
@@ -40,6 +45,7 @@ protocol CalendarServiceProviding {
     func rescheduleReminder(id: String, to: Date, isAllDay: Bool) -> Completable
 
     func changeEventStatus(id: String, date: Date, to: EventStatus) -> Completable
+    func deleteEvent(id: String, date: Date, scope: EventDeletionScope) -> Completable
 
     @MainActor func requestAccess()
 }
@@ -404,11 +410,7 @@ class CalendarServiceProvider: CalendarServiceProviding {
             let disposable = Disposables.create()
 
             do {
-                let predicate = store.predicateForEvents(withStart: date, end: date + 1, calendars: nil)
-
-                guard let event = store.events(matching: predicate).first(where: { $0.calendarItemIdentifier == id }) else {
-                    throw .unexpected("🔥 Event not found")
-                }
+                let event = try findEvent(id: id, date: date, in: store)
 
                 guard let user = event.currentUser else {
                     throw .unexpected("🔥 User not found")
@@ -461,6 +463,27 @@ class CalendarServiceProvider: CalendarServiceProviding {
         .subscribe(on: ConcurrentDispatchQueueScheduler(qos: .userInteractive))
     }
 
+    func deleteEvent(id: String, date: Date, scope: EventDeletionScope) -> Completable {
+
+        Completable.create { [store] observer in
+            do {
+                let event = try findEvent(id: id, date: date, in: store)
+
+                guard event.calendar.allowsContentModifications else {
+                    throw .unexpected("Calendar does not allow event deletion")
+                }
+
+                try store.remove(event, span: scope.eventKitSpan, commit: true)
+                observer(.completed)
+            } catch {
+                observer(.error(error))
+            }
+
+            return Disposables.create()
+        }
+        .subscribe(on: ConcurrentDispatchQueueScheduler(qos: .userInteractive))
+    }
+
     private func dueDateComponents(for date: Date, isAllDay: Bool) -> DateComponents {
         // The components calendar must be Gregorian, otherwise an exception is raised.
         var components = date.dateComponents(using: dateProvider, calendar: .gregorian)
@@ -483,6 +506,27 @@ class CalendarServiceProvider: CalendarServiceProviding {
 
         return (startDay, exclusiveEnd)
     }
+}
+
+private extension EventDeletionScope {
+
+    var eventKitSpan: EKSpan {
+        switch self {
+        case .thisEvent: .thisEvent
+        case .futureEvents: .futureEvents
+        }
+    }
+}
+
+private func findEvent(id: String, date: Date, in store: EKEventStore) throws -> EKEvent {
+    let predicate = store.predicateForEvents(withStart: date, end: date + 1, calendars: nil)
+
+    guard let event = store.events(matching: predicate).first(where: {
+        $0.calendarItemIdentifier == id && $0.startDate == date
+    }) else {
+        throw .unexpected("🔥 Event not found")
+    }
+    return event
 }
 
 private class EventStore: EKEventStore {
@@ -623,7 +667,8 @@ private extension CalendarModel {
             account: .init(from: calendar),
             title: calendar.title,
             color: calendar.color,
-            isSubscribed: calendar.isSubscribed || calendar.isDelegate
+            isSubscribed: calendar.isSubscribed || calendar.isDelegate,
+            allowsContentModifications: calendar.allowsContentModifications
         )
     }
 }

--- a/CalendrTests/EventOptionsViewModelTests.swift
+++ b/CalendrTests/EventOptionsViewModelTests.swift
@@ -191,7 +191,7 @@ class EventOptionsViewModelTests {
         #expect(viewModel.items == [.action(.open)])
     }
 
-    @Test func testDeleteStandaloneEvent_deletesOnlyThatEventWithoutConfirmation() {
+    @Test func testDeleteStandaloneEvent_withConfirmation_deletesOnlyThatEvent() {
         let start: Date = .make(year: 2026, month: 8, day: 9, hour: 14)
         let confirmation = MockEventDeletionConfirmation(scope: .futureEvents)
         var deletedEvent: DeleteEventArgs?
@@ -208,10 +208,32 @@ class EventOptionsViewModelTests {
 
         viewModel.triggerAction(.delete)
 
-        #expect(confirmation.callCount == 0)
+        #expect(confirmation.callCount == 1)
+        #expect(confirmation.receivedIsRecurring == false)
         #expect(deletedEvent?.id == "event-id")
         #expect(deletedEvent?.date == start)
         #expect(deletedEvent?.scope == .thisEvent)
+    }
+
+    @Test func testDeleteStandaloneEvent_withCancelledConfirmation_doesNotDelete() {
+        let confirmation = MockEventDeletionConfirmation(scope: nil)
+        var deletedEvent: DeleteEventArgs?
+
+        calendarService.spyDeleteEventObservable
+            .bind { deletedEvent = $0 }
+            .disposed(by: disposeBag)
+
+        let viewModel = mock(
+            event: .make(type: .event(.unknown)),
+            source: .calendar,
+            deletionConfirmation: confirmation
+        )
+
+        viewModel.triggerAction(.delete)
+
+        #expect(confirmation.callCount == 1)
+        #expect(confirmation.receivedIsRecurring == false)
+        #expect(deletedEvent == nil)
     }
 
     @Test func testDeleteRecurringEvent_withThisEventConfirmation() {
@@ -232,6 +254,7 @@ class EventOptionsViewModelTests {
         viewModel.triggerAction(.delete)
 
         #expect(confirmation.callCount == 1)
+        #expect(confirmation.receivedIsRecurring == true)
         #expect(deletedEvent?.scope == .thisEvent)
     }
 
@@ -339,13 +362,15 @@ private final class MockEventDeletionConfirmation: EventDeletionConfirming {
 
     private let scope: EventDeletionScope?
     private(set) var callCount = 0
+    private(set) var receivedIsRecurring: Bool?
 
     init(scope: EventDeletionScope? = nil) {
         self.scope = scope
     }
 
-    func confirmDeletion() -> EventDeletionScope? {
+    func confirmDeletion(isRecurring: Bool) -> EventDeletionScope? {
         callCount += 1
+        receivedIsRecurring = isRecurring
         return scope
     }
 }

--- a/CalendrTests/EventOptionsViewModelTests.swift
+++ b/CalendrTests/EventOptionsViewModelTests.swift
@@ -79,7 +79,7 @@ class EventOptionsViewModelTests {
     @Test func testOptions_fromList_withUnknownInvitationStatus() {
 
         let viewModel = mock(event: .make(type: .event(.unknown)), source: .calendar)
-        #expect(viewModel.items == [.action(.open)])
+        #expect(viewModel.items == [.action(.open), .separator, .action(.delete)])
     }
 
     @Test func testOptions_fromList_withUnknownInvitationStatus_withLink() {
@@ -88,7 +88,9 @@ class EventOptionsViewModelTests {
         #expect(viewModel.items == [
             .action(.open),
             .separator,
-            .action(.link(.zoomLink, isInProgress: false))
+            .action(.link(.zoomLink, isInProgress: false)),
+            .separator,
+            .action(.delete)
         ])
     }
 
@@ -100,7 +102,9 @@ class EventOptionsViewModelTests {
             .separator,
             .action(.status(.accept)),
             .action(.status(.maybe)),
-            .action(.status(.decline))
+            .action(.status(.decline)),
+            .separator,
+            .action(.delete)
         ])
     }
 
@@ -114,7 +118,9 @@ class EventOptionsViewModelTests {
             .separator,
             .action(.status(.accept)),
             .action(.status(.maybe)),
-            .action(.status(.decline))
+            .action(.status(.decline)),
+            .separator,
+            .action(.delete)
         ])
     }
 
@@ -166,6 +172,109 @@ class EventOptionsViewModelTests {
         ])
     }
 
+    @Test func testOptions_fromList_withReadOnlyCalendar_doesNotIncludeDelete() {
+
+        let event = EventModel.make(
+            type: .event(.unknown),
+            calendar: .make(allowsContentModifications: false)
+        )
+
+        let viewModel = mock(event: event, source: .calendar)
+
+        #expect(viewModel.items == [.action(.open)])
+    }
+
+    @Test func testOptions_fromList_withBirthday_doesNotIncludeDelete() {
+
+        let viewModel = mock(event: .make(type: .birthday), source: .calendar)
+
+        #expect(viewModel.items == [.action(.open)])
+    }
+
+    @Test func testDeleteStandaloneEvent_deletesOnlyThatEventWithoutConfirmation() {
+        let start: Date = .make(year: 2026, month: 8, day: 9, hour: 14)
+        let confirmation = MockEventDeletionConfirmation(scope: .futureEvents)
+        var deletedEvent: DeleteEventArgs?
+
+        calendarService.spyDeleteEventObservable
+            .bind { deletedEvent = $0 }
+            .disposed(by: disposeBag)
+
+        let viewModel = mock(
+            event: .make(id: "event-id", start: start, type: .event(.unknown)),
+            source: .calendar,
+            deletionConfirmation: confirmation
+        )
+
+        viewModel.triggerAction(.delete)
+
+        #expect(confirmation.callCount == 0)
+        #expect(deletedEvent?.id == "event-id")
+        #expect(deletedEvent?.date == start)
+        #expect(deletedEvent?.scope == .thisEvent)
+    }
+
+    @Test func testDeleteRecurringEvent_withThisEventConfirmation() {
+        let start: Date = .make(year: 2026, month: 8, day: 9, hour: 14)
+        let confirmation = MockEventDeletionConfirmation(scope: .thisEvent)
+        var deletedEvent: DeleteEventArgs?
+
+        calendarService.spyDeleteEventObservable
+            .bind { deletedEvent = $0 }
+            .disposed(by: disposeBag)
+
+        let viewModel = mock(
+            event: .make(id: "event-id", start: start, type: .event(.unknown), hasRecurrenceRules: true),
+            source: .calendar,
+            deletionConfirmation: confirmation
+        )
+
+        viewModel.triggerAction(.delete)
+
+        #expect(confirmation.callCount == 1)
+        #expect(deletedEvent?.scope == .thisEvent)
+    }
+
+    @Test func testDeleteRecurringEvent_withFutureEventsConfirmation() {
+        let confirmation = MockEventDeletionConfirmation(scope: .futureEvents)
+        var deletedEvent: DeleteEventArgs?
+
+        calendarService.spyDeleteEventObservable
+            .bind { deletedEvent = $0 }
+            .disposed(by: disposeBag)
+
+        let viewModel = mock(
+            event: .make(type: .event(.unknown), hasRecurrenceRules: true),
+            source: .calendar,
+            deletionConfirmation: confirmation
+        )
+
+        viewModel.triggerAction(.delete)
+
+        #expect(confirmation.callCount == 1)
+        #expect(deletedEvent?.scope == .futureEvents)
+    }
+
+    @Test func testDeleteRecurringEvent_withCancelledConfirmation_doesNotDelete() {
+        let confirmation = MockEventDeletionConfirmation(scope: nil)
+        var deletedEvent: DeleteEventArgs?
+
+        calendarService.spyDeleteEventObservable
+            .bind { deletedEvent = $0 }
+            .disposed(by: disposeBag)
+
+        let viewModel = mock(
+            event: .make(type: .event(.unknown), hasRecurrenceRules: true),
+            source: .calendar,
+            deletionConfirmation: confirmation
+        )
+
+        viewModel.triggerAction(.delete)
+
+        #expect(confirmation.callCount == 1)
+        #expect(deletedEvent == nil)
+    }
+
     @Test func testOptions_withOpenTriggered() async {
         let openExpectation = expectation(description: "Open")
 
@@ -202,11 +311,17 @@ class EventOptionsViewModelTests {
         )
     }
 
+    @Test func testDeleteAction() {
+        #expect(EventAction.delete.title == Strings.Event.Action.delete)
+        #expect(EventAction.delete.icon == Icons.Event.delete)
+    }
+
     func mock(
         event: EventModel,
         source: ContextMenuSource,
-        callback: @escaping (EventAction?) -> Void = { _ in }
-    ) -> some ContextMenuViewModel<EventAction> {
+        callback: @escaping (EventAction?) -> Void = { _ in },
+        deletionConfirmation: EventDeletionConfirming = MockEventDeletionConfirmation()
+    ) -> EventOptionsViewModel {
 
         EventOptionsViewModel(
             event: event,
@@ -214,8 +329,24 @@ class EventOptionsViewModelTests {
             calendarService: calendarService,
             workspace: workspace,
             source: source,
-            callback: .init { callback($0.element) }
+            callback: .init { callback($0.element) },
+            deletionConfirmation: deletionConfirmation
         )!
+    }
+}
+
+private final class MockEventDeletionConfirmation: EventDeletionConfirming {
+
+    private let scope: EventDeletionScope?
+    private(set) var callCount = 0
+
+    init(scope: EventDeletionScope? = nil) {
+        self.scope = scope
+    }
+
+    func confirmDeletion() -> EventDeletionScope? {
+        callCount += 1
+        return scope
     }
 }
 

--- a/MISSING_TRANSLATIONS.md
+++ b/MISSING_TRANSLATIONS.md
@@ -1,25 +1,25 @@
 # The following languages have missing translations
 Language|Count
 -|-
-[German - Deutsch - (de)](Calendr/Assets/de.lproj/Localizable.strings)|56
-[Hebrew - עברית - (he)](Calendr/Assets/he.lproj/Localizable.strings)|35
-[Chinese - 中文 - (zh-Hant-TW)](Calendr/Assets/zh-Hant-TW.lproj/Localizable.strings)|54
-[Greek - Ελληνικά - (el)](Calendr/Assets/el.lproj/Localizable.strings)|57
-[Chinese - 中文 - (zh-Hans)](Calendr/Assets/zh-Hans.lproj/Localizable.strings)|35
-[Japanese - 日本語 - (ja)](Calendr/Assets/ja.lproj/Localizable.strings)|9
-[Albanian - shqip - (sq)](Calendr/Assets/sq.lproj/Localizable.strings)|57
-[Ukrainian - українська - (uk)](Calendr/Assets/uk.lproj/Localizable.strings)|51
-[Spanish - español - (es)](Calendr/Assets/es.lproj/Localizable.strings)|57
-[Italian - italiano - (it)](Calendr/Assets/it.lproj/Localizable.strings)|54
-[Slovak - slovenčina - (sk)](Calendr/Assets/sk.lproj/Localizable.strings)|34
-[Swedish - svenska - (sv)](Calendr/Assets/sv.lproj/Localizable.strings)|57
-[Korean - 한국어 - (ko)](Calendr/Assets/ko.lproj/Localizable.strings)|32
-[Turkish - Türkçe - (tr)](Calendr/Assets/tr.lproj/Localizable.strings)|35
-[Polish - polski - (pl)](Calendr/Assets/pl.lproj/Localizable.strings)|34
-[Russian - русский - (ru)](Calendr/Assets/ru.lproj/Localizable.strings)|37
-[French - français - (fr)](Calendr/Assets/fr.lproj/Localizable.strings)|49
-[Dutch - Nederlands - (nl)](Calendr/Assets/nl.lproj/Localizable.strings)|51
-[Portuguese - português - (pt)](Calendr/Assets/pt.lproj/Localizable.strings)|1
+[German - Deutsch - (de)](Calendr/Assets/de.lproj/Localizable.strings)|62
+[Hebrew - עברית - (he)](Calendr/Assets/he.lproj/Localizable.strings)|41
+[Chinese - 中文 - (zh-Hant-TW)](Calendr/Assets/zh-Hant-TW.lproj/Localizable.strings)|60
+[Greek - Ελληνικά - (el)](Calendr/Assets/el.lproj/Localizable.strings)|63
+[Chinese - 中文 - (zh-Hans)](Calendr/Assets/zh-Hans.lproj/Localizable.strings)|41
+[Japanese - 日本語 - (ja)](Calendr/Assets/ja.lproj/Localizable.strings)|15
+[Albanian - shqip - (sq)](Calendr/Assets/sq.lproj/Localizable.strings)|63
+[Ukrainian - українська - (uk)](Calendr/Assets/uk.lproj/Localizable.strings)|57
+[Spanish - español - (es)](Calendr/Assets/es.lproj/Localizable.strings)|63
+[Italian - italiano - (it)](Calendr/Assets/it.lproj/Localizable.strings)|60
+[Slovak - slovenčina - (sk)](Calendr/Assets/sk.lproj/Localizable.strings)|40
+[Swedish - svenska - (sv)](Calendr/Assets/sv.lproj/Localizable.strings)|63
+[Korean - 한국어 - (ko)](Calendr/Assets/ko.lproj/Localizable.strings)|38
+[Turkish - Türkçe - (tr)](Calendr/Assets/tr.lproj/Localizable.strings)|41
+[Polish - polski - (pl)](Calendr/Assets/pl.lproj/Localizable.strings)|40
+[Russian - русский - (ru)](Calendr/Assets/ru.lproj/Localizable.strings)|43
+[French - français - (fr)](Calendr/Assets/fr.lproj/Localizable.strings)|55
+[Dutch - Nederlands - (nl)](Calendr/Assets/nl.lproj/Localizable.strings)|57
+[Portuguese - português - (pt)](Calendr/Assets/pt.lproj/Localizable.strings)|7
 
 Feel free to open a new issue or pull request with the missing values.
 

--- a/MISSING_TRANSLATIONS.md
+++ b/MISSING_TRANSLATIONS.md
@@ -1,25 +1,25 @@
 # The following languages have missing translations
 Language|Count
 -|-
-[German - Deutsch - (de)](Calendr/Assets/de.lproj/Localizable.strings)|62
-[Hebrew - עברית - (he)](Calendr/Assets/he.lproj/Localizable.strings)|41
-[Chinese - 中文 - (zh-Hant-TW)](Calendr/Assets/zh-Hant-TW.lproj/Localizable.strings)|60
-[Greek - Ελληνικά - (el)](Calendr/Assets/el.lproj/Localizable.strings)|63
-[Chinese - 中文 - (zh-Hans)](Calendr/Assets/zh-Hans.lproj/Localizable.strings)|41
-[Japanese - 日本語 - (ja)](Calendr/Assets/ja.lproj/Localizable.strings)|15
-[Albanian - shqip - (sq)](Calendr/Assets/sq.lproj/Localizable.strings)|63
-[Ukrainian - українська - (uk)](Calendr/Assets/uk.lproj/Localizable.strings)|57
-[Spanish - español - (es)](Calendr/Assets/es.lproj/Localizable.strings)|63
-[Italian - italiano - (it)](Calendr/Assets/it.lproj/Localizable.strings)|60
-[Slovak - slovenčina - (sk)](Calendr/Assets/sk.lproj/Localizable.strings)|40
-[Swedish - svenska - (sv)](Calendr/Assets/sv.lproj/Localizable.strings)|63
-[Korean - 한국어 - (ko)](Calendr/Assets/ko.lproj/Localizable.strings)|38
-[Turkish - Türkçe - (tr)](Calendr/Assets/tr.lproj/Localizable.strings)|41
-[Polish - polski - (pl)](Calendr/Assets/pl.lproj/Localizable.strings)|40
-[Russian - русский - (ru)](Calendr/Assets/ru.lproj/Localizable.strings)|43
-[French - français - (fr)](Calendr/Assets/fr.lproj/Localizable.strings)|55
-[Dutch - Nederlands - (nl)](Calendr/Assets/nl.lproj/Localizable.strings)|57
-[Portuguese - português - (pt)](Calendr/Assets/pt.lproj/Localizable.strings)|7
+[German - Deutsch - (de)](Calendr/Assets/de.lproj/Localizable.strings)|63
+[Hebrew - עברית - (he)](Calendr/Assets/he.lproj/Localizable.strings)|42
+[Chinese - 中文 - (zh-Hant-TW)](Calendr/Assets/zh-Hant-TW.lproj/Localizable.strings)|61
+[Greek - Ελληνικά - (el)](Calendr/Assets/el.lproj/Localizable.strings)|64
+[Chinese - 中文 - (zh-Hans)](Calendr/Assets/zh-Hans.lproj/Localizable.strings)|42
+[Japanese - 日本語 - (ja)](Calendr/Assets/ja.lproj/Localizable.strings)|16
+[Albanian - shqip - (sq)](Calendr/Assets/sq.lproj/Localizable.strings)|64
+[Ukrainian - українська - (uk)](Calendr/Assets/uk.lproj/Localizable.strings)|58
+[Spanish - español - (es)](Calendr/Assets/es.lproj/Localizable.strings)|64
+[Italian - italiano - (it)](Calendr/Assets/it.lproj/Localizable.strings)|61
+[Slovak - slovenčina - (sk)](Calendr/Assets/sk.lproj/Localizable.strings)|41
+[Swedish - svenska - (sv)](Calendr/Assets/sv.lproj/Localizable.strings)|64
+[Korean - 한국어 - (ko)](Calendr/Assets/ko.lproj/Localizable.strings)|39
+[Turkish - Türkçe - (tr)](Calendr/Assets/tr.lproj/Localizable.strings)|42
+[Polish - polski - (pl)](Calendr/Assets/pl.lproj/Localizable.strings)|41
+[Russian - русский - (ru)](Calendr/Assets/ru.lproj/Localizable.strings)|44
+[French - français - (fr)](Calendr/Assets/fr.lproj/Localizable.strings)|56
+[Dutch - Nederlands - (nl)](Calendr/Assets/nl.lproj/Localizable.strings)|58
+[Portuguese - português - (pt)](Calendr/Assets/pt.lproj/Localizable.strings)|8
 
 Feel free to open a new issue or pull request with the missing values.
 


### PR DESCRIPTION
## Summary

- Add a Delete action to the calendar event context menu
- Ask for confirmation before deleting standalone events
- For recurring events, offer to delete only the selected occurrence or all future occurrences
- Hide the action for birthdays and read-only calendars
- Add English and Czech localization, with other missing translations tracked

I hope this feature is within the scope. To me, it feels like another small step toward handling everyday calendar tasks directly in Calendr without needing to open the regular Calendar app.