### PR TITLE
Separate local and global shortcuts in settings

### DIFF
--- a/Calendr/Settings/KeyboardViewController.swift
+++ b/Calendr/Settings/KeyboardViewController.swift
@@ -46,10 +46,6 @@ class KeyboardViewController: NSViewController, SettingsUI {
         scrollView.contentView.top(equalTo: contentStackView)
         scrollView.contentView.leading(equalTo: contentStackView)
         scrollView.contentView.trailing(equalTo: contentStackView)
-        scrollView.contentView.height(
-            equalTo: contentStackView,
-            priority: .dragThatCanResizeWindow
-        )
 
         let stackView = NSStackView(views: [shortcutsControl, scrollView])
         .with(spacing: Constants.contentSpacing)

--- a/Calendr/Settings/KeyboardViewController.swift
+++ b/Calendr/Settings/KeyboardViewController.swift
@@ -46,8 +46,10 @@ class KeyboardViewController: NSViewController, SettingsUI {
         scrollView.contentView.top(equalTo: contentStackView)
         scrollView.contentView.leading(equalTo: contentStackView)
         scrollView.contentView.trailing(equalTo: contentStackView)
-        scrollView.contentView.height(equalTo: contentStackView)
-            .priority = .dragThatCanResizeWindow
+        scrollView.contentView.height(
+            equalTo: contentStackView,
+            priority: .dragThatCanResizeWindow
+        )
 
         let stackView = NSStackView(views: [shortcutsControl, scrollView])
         .with(spacing: Constants.contentSpacing)

--- a/Calendr/Settings/KeyboardViewController.swift
+++ b/Calendr/Settings/KeyboardViewController.swift
@@ -12,6 +12,18 @@ import KeyboardShortcuts
 class KeyboardViewController: NSViewController, SettingsUI {
 
     private let disposeBag = DisposeBag()
+    private let scaling: Observable<Double>
+
+    init(scaling: Observable<Double> = Scaling.observable) {
+
+        self.scaling = scaling
+
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
 
     private lazy var shortcutsControl = NSSegmentedControl(
         labels: [LocalShortcuts.title, GlobalShortcuts.title],
@@ -38,16 +50,7 @@ class KeyboardViewController: NSViewController, SettingsUI {
         let contentStackView = NSStackView(views: [localContent, globalContent])
             .with(orientation: .vertical)
 
-        let scrollView = NSScrollView()
-        scrollView.drawsBackground = false
-        scrollView.documentView = contentStackView.forAutoLayout()
-
-        scrollView.contentView.edges(equalTo: scrollView)
-        scrollView.contentView.top(equalTo: contentStackView)
-        scrollView.contentView.leading(equalTo: contentStackView)
-        scrollView.contentView.trailing(equalTo: contentStackView)
-
-        let stackView = NSStackView(views: [shortcutsControl, scrollView])
+        let stackView = NSStackView(views: [shortcutsControl, contentStackView])
         .with(spacing: Constants.contentSpacing)
         .with(orientation: .vertical)
 
@@ -55,7 +58,7 @@ class KeyboardViewController: NSViewController, SettingsUI {
 
         stackView.edges(equalTo: view, margins: .init(bottom: 1))
 
-        Scaling.observable
+        scaling
             .map { CGFloat(16 * $0) }
             .bind(to: commandCharWidth.width(equalTo: 1).rx.constant)
             .disposed(by: disposeBag)
@@ -116,13 +119,18 @@ class KeyboardViewController: NSViewController, SettingsUI {
 
     private func makeLabel(text: String) -> NSView {
 
-        Label(text: text, font: .systemFont(ofSize: 13))
+        Label(text: text, font: .systemFont(ofSize: 13), scaling: scaling)
     }
 
     private func makeCommand(text: String) -> NSView {
 
         let charViews = text.split(separator: " ").map {
-            Label(text: String($0), font: .systemFont(ofSize: 13, weight: .regular), align: .center)
+            Label(
+                text: String($0),
+                font: .systemFont(ofSize: 13, weight: .regular),
+                align: .center,
+                scaling: scaling
+            )
         }
 
         // defer until after they are in the same hierarchy

--- a/Calendr/Settings/KeyboardViewController.swift
+++ b/Calendr/Settings/KeyboardViewController.swift
@@ -13,6 +13,13 @@ class KeyboardViewController: NSViewController, SettingsUI {
 
     private let disposeBag = DisposeBag()
 
+    private lazy var shortcutsControl = NSSegmentedControl(
+        labels: [LocalShortcuts.title, GlobalShortcuts.title],
+        trackingMode: .selectOne,
+        target: self,
+        action: #selector(shortcutsControlChanged)
+    )
+
     typealias LocalShortcuts = Strings.Settings.Keyboard.LocalShortcuts
     typealias GlobalShortcuts = Strings.Settings.Keyboard.GlobalShortcuts
 
@@ -24,13 +31,25 @@ class KeyboardViewController: NSViewController, SettingsUI {
 
         view.addLayoutGuide(commandCharWidth)
 
-        let stackView = NSStackView(
-            views: Sections.create([
-                makeSection(title: LocalShortcuts.title, content: localContent),
-                makeSection(title: GlobalShortcuts.title, content: globalContent),
-            ])
-            .disposed(by: disposeBag)
-        )
+        shortcutsControl.selectedSegment = 0
+
+        globalContent.isHidden = true
+
+        let contentStackView = NSStackView(views: [localContent, globalContent])
+            .with(orientation: .vertical)
+
+        let scrollView = NSScrollView()
+        scrollView.drawsBackground = false
+        scrollView.documentView = contentStackView.forAutoLayout()
+
+        scrollView.contentView.edges(equalTo: scrollView)
+        scrollView.contentView.top(equalTo: contentStackView)
+        scrollView.contentView.leading(equalTo: contentStackView)
+        scrollView.contentView.trailing(equalTo: contentStackView)
+        scrollView.contentView.height(equalTo: contentStackView)
+            .priority = .dragThatCanResizeWindow
+
+        let stackView = NSStackView(views: [shortcutsControl, scrollView])
         .with(spacing: Constants.contentSpacing)
         .with(orientation: .vertical)
 
@@ -42,6 +61,12 @@ class KeyboardViewController: NSViewController, SettingsUI {
             .map { CGFloat(16 * $0) }
             .bind(to: commandCharWidth.width(equalTo: 1).rx.constant)
             .disposed(by: disposeBag)
+    }
+
+    @objc private func shortcutsControlChanged() {
+
+        localContent.isHidden = shortcutsControl.selectedSegment != 0
+        globalContent.isHidden = shortcutsControl.selectedSegment != 1
     }
 
     private lazy var localContent: NSView = {

--- a/CalendrTests/KeyboardViewControllerTests.swift
+++ b/CalendrTests/KeyboardViewControllerTests.swift
@@ -1,0 +1,56 @@
+//
+//  KeyboardViewControllerTests.swift
+//  CalendrTests
+//
+
+import AppKit
+import RxSwift
+import Testing
+@testable import Calendr
+
+@MainActor
+struct KeyboardViewControllerTests {
+
+    @Test func shortcutControlShowsOneSectionAtATime() throws {
+
+        let controller = KeyboardViewController(scaling: .just(1))
+        _ = controller.view
+        controller.view.layoutSubtreeIfNeeded()
+
+        let control = try #require(controller.view.firstDescendant(ofType: NSSegmentedControl.self))
+        let contentStackView = try #require(
+            controller.view
+                .firstDescendant(ofType: NSStackView.self) {
+                    $0.arrangedSubviews.count == 2 && $0.arrangedSubviews.allSatisfy { $0 is NSStackView }
+                }
+        )
+
+        #expect(controller.view.firstDescendant(ofType: NSScrollView.self) == nil)
+        #expect(contentStackView.arrangedSubviews[0].isHidden == false)
+        #expect(contentStackView.arrangedSubviews[1].isHidden == true)
+        #expect(controller.view.fittingSize.height < 600)
+
+        control.selectedSegment = 1
+        _ = control.target?.perform(control.action, with: control)
+        controller.view.layoutSubtreeIfNeeded()
+
+        #expect(contentStackView.arrangedSubviews[0].isHidden == true)
+        #expect(contentStackView.arrangedSubviews[1].isHidden == false)
+        #expect(controller.view.fittingSize.height < 600)
+    }
+}
+
+private extension NSView {
+
+    func firstDescendant<T: NSView>(
+        ofType type: T.Type,
+        where predicate: @escaping (T) -> Bool = { _ in true }
+    ) -> T? {
+
+        if let match = self as? T, predicate(match) {
+            return match
+        }
+
+        return subviews.lazy.compactMap { $0.firstDescendant(ofType: type, where: predicate) }.first
+    }
+}


### PR DESCRIPTION
## Summary
- replace the two always-visible shortcut sections with a Local/Global segmented control
- show only the selected shortcut group
- place the shortcut content in a scroll view so the settings panel remains usable as more shortcuts are added



## Testing
- `swift test --disable-sandbox --scratch-path /tmp/calendr-scratch`
- 647 tests across 39 suites passed