### PR TITLE
Fix year parsed from trailing number in date search

### DIFF
--- a/Calendr/Utils/DateSearchParser.swift
+++ b/Calendr/Utils/DateSearchParser.swift
@@ -74,14 +74,20 @@ private func searchMatchMonth(text: String, symbols: [String], dateProvider: Dat
 
             components.month = index + 1
 
-            // extract year if it exists after the month
+            // extract a year only from a standalone 4-digit number that directly
+            // follows the month (separated only by whitespace), so unrelated
+            // trailing numbers — room numbers, issue ids, or a longer digit run —
+            // are not mistaken for the year
             var extendedRange = range
-            if let yearRange = text[range.upperBound...].range(of: #"(\d{4})"#, options: .regularExpression) {
-                if let yearStr = Int(text[yearRange].trimmingCharacters(in: .whitespaces)) {
-                    components.year = yearStr
-                    // Extend the range to include the year
-                    extendedRange = range.lowerBound..<yearRange.upperBound
-                }
+            let tail = text[range.upperBound...].drop(while: { $0.isWhitespace })
+            if
+                let yearRange = tail.range(of: #"\d{4}(?!\d)"#, options: .regularExpression),
+                yearRange.lowerBound == tail.startIndex,
+                let yearStr = Int(tail[yearRange])
+            {
+                components.year = yearStr
+                // Extend the range to include the year
+                extendedRange = range.lowerBound..<yearRange.upperBound
             }
 
             // create the date from components

--- a/CalendrTests/DateSearchParserTests.swift
+++ b/CalendrTests/DateSearchParserTests.swift
@@ -87,9 +87,45 @@ class DateSearchParserTests {
         #expect(result == "𠮷")
     }
 
-    @Test func testInvalidDates() throws {
+    @Test func testYearIsNotExtractedFromTrailingNumber() throws {
+        // An unrelated 4-digit number after the month (room/issue id, etc.) must
+        // not be parsed as the year. With no year present, it falls back to the
+        // current year (2021, from the fixed `dateProvider.now`).
+        let formatter = DateFormatter(calendar: dateProvider.calendar)
+        formatter.dateStyle = .short
 
-        let dateStrings: [String] = [
+        for text in ["Dec room 1234", "Dec #1234", "Dec sync 1234"] {
+            let (date, _) = try #require(DateSearchParser.parse(text: text, using: dateProvider), "\(text)")
+            #expect(formatter.string(from: date) == "18/12/2021", "\(text)")
+        }
+    }
+
+    @Test func testYearIsNotExtractedFromLongerNumberRun() throws {
+        // A 4-digit year must not be matched inside a longer digit run. No valid
+        // year is found, so only the month token is consumed and the run stays in
+        // the remaining search text.
+        let (date, result) = try #require(DateSearchParser.parse(text: "Dec 20215", using: dateProvider))
+
+        let formatter = DateFormatter(calendar: dateProvider.calendar)
+        formatter.dateStyle = .short
+
+        #expect(formatter.string(from: date) == "18/12/2021")
+        #expect(result == "20215")
+    }
+
+    @Test func testAdjacentYearIsStillExtracted() throws {
+        // A standalone 4-digit year directly after the month keeps working, even
+        // when trailing text follows it.
+        let formatter = DateFormatter(calendar: dateProvider.calendar)
+        formatter.dateStyle = .short
+
+        for text in ["Dec 2021", "Dec 2021 Suffix", "Prefix Dec 2021"] {
+            let (date, _) = try #require(DateSearchParser.parse(text: text, using: dateProvider), "\(text)")
+            #expect(formatter.string(from: date) == "18/12/2021", "\(text)")
+        }
+    }
+
+    @Test func testInvalidDates() throws {        let dateStrings: [String] = [
             "2021-12-118",
             "Decembers 18, 2021",
             "18 Decembers 2021",


### PR DESCRIPTION
## Summary

`DateSearchParser.searchMatchMonth` parsed the year as the first 4-digit run found **anywhere** after the month name. As a result, an unrelated trailing number was mistaken for the year.

## Root cause

```swift
text[range.upperBound...].range(of: #"(\d{4})"#, options: .regularExpression)
```

This scans the whole remainder of the search text after the month, with no constraint that the 4 digits be adjacent to the month or form a standalone number. Concretely:

- `\"Dec room 1234\"` → year **1234** (a room/issue number)
- `\"Dec #1234\"`      → year **1234**
- `\"Dec 20215\"`      → year **2021** matched inside the longer run, leaving an orphan `\"5\"` in the result text

## Changes

`Calendr/Utils/DateSearchParser.swift` — only treat a **standalone** 4-digit number (`\\d{4}(?!\\d)`) that **directly follows the month** (separated only by whitespace) as the year. With no such token, the year falls back to the current year as before.

Plain cases like `\"Dec 2021\"`, `\"Prefix Dec 2021\"` and `\"Dec 2021 Suffix\"` keep working unchanged.

## Test plan

- [x] `swift test --filter DateSearchParserTests`
- Added `testYearIsNotExtractedFromTrailingNumber`, `testYearIsNotExtractedFromLongerNumberRun`, `testAdjacentYearIsStillExtracted` — confirmed red before the change (`18/12/1234`) and green after (`18/12/2021`).
- All previously passing `DateSearchParserTests` cases remain green.