### PR TITLE
Fix LRUCache crash with non-positive capacity

### DIFF
--- a/Calendr/Utils/Cache.swift
+++ b/Calendr/Utils/Cache.swift
@@ -52,6 +52,11 @@ class LRUCache<Key: Hashable, Value>: Cache {
     }
 
     private func unsafe_set(_ key: Key, _ value: Value) {
+        // A non-positive capacity cache holds nothing; bail out before reaching
+        // the eviction branch, whose `order.removeFirst()` would trap on the
+        // empty ordering array.
+        guard capacity > 0 else { return }
+
         if cache[key] != nil {
             // If the key already exists, update the value and move it to the end
             if let index = order.firstIndex(of: key) {

--- a/CalendrTests/CacheTests.swift
+++ b/CalendrTests/CacheTests.swift
@@ -52,4 +52,22 @@ class CacheTests {
         #expect(cache.get("K3") == "V3")
         #expect(cache.get("K5") == "V5")
     }
+
+    @Test func testZeroCapacityDoesNotCrash() {
+
+        let cache = LRUCache<String, String>(capacity: 0)
+
+        cache.set("K1", "V1")
+
+        #expect(cache.get("K1") == nil)
+    }
+
+    @Test func testNegativeCapacityDoesNotCrash() {
+
+        let cache = LRUCache<String, String>(capacity: -1)
+
+        cache.set("K1", "V1")
+
+        #expect(cache.get("K1") == nil)
+    }
 }


### PR DESCRIPTION
## Summary

`LRUCache` traps (fatal error) when initialised with a capacity of `0` (or any non-positive value) and a value is then stored.

## Root cause

`unsafe_set` enters its eviction branch whenever a new key is inserted and `cache.count >= capacity`:

```swift
} else if cache.count >= capacity {
    let leastUsedKey = order.removeFirst()   // traps: `order` is still empty
    cache.removeValue(forKey: leastUsedKey)
}
```

With `capacity <= 0` this condition is true on the very first `set`, so `order.removeFirst()` is called on an empty array → `Array index out of range`.

## Changes

`Calendr/Utils/Cache.swift` — bail out of `unsafe_set` when `capacity <= 0`. A non-positive-capacity cache holds nothing, so `set` is a no-op and `get` returns `nil`. Existing capacity `>= 1` behaviour is unchanged.

## Test plan

- [x] `swift test --filter CacheTests`
- Added `testZeroCapacityDoesNotCrash` and `testNegativeCapacityDoesNotCrash` — confirmed red before the change (process trapped with signal 5 on `set`) and green after.
- `testCapacity` and `testDropLeastRecentlyUsed` still pass.