### PR TITLE
Add Chinese lunar dates, mainland holidays, and solar terms

### DIFF
--- a/Calendr/Assets/en.lproj/Localizable.strings
+++ b/Calendr/Assets/en.lproj/Localizable.strings
@@ -46,6 +46,7 @@
 
 "settings.menu_bar.show_icon" = "Show icon";
 "settings.menu_bar.show_date" = "Show date";
+"settings.menu_bar.show_lunar_date" = "Show lunar date";
 "settings.menu_bar.date_format_custom" = "Custom";
 
 "settings.menu_bar.background" = "Background";
@@ -66,6 +67,9 @@
 "settings.calendar" = "Calendar";
 "settings.calendar.show_month_outline" = "Show month outline";
 "settings.calendar.show_week_numbers" = "Show week numbers";
+"settings.calendar.show_lunar_calendar" = "Show Chinese lunar dates";
+"settings.calendar.show_mainland_holidays" = "Show mainland holidays";
+"settings.calendar.show_solar_terms" = "Show solar terms";
 "settings.calendar.preserve_selected_date" = "Preserve selected date on hide";
 "settings.calendar.show_declined_events" = "Show declined events";
 "settings.calendar.show_declined_events_tooltip" = "This only works if it is also enabled in the native Calendar app.";

--- a/Calendr/Assets/zh-Hans.lproj/Localizable.strings
+++ b/Calendr/Assets/zh-Hans.lproj/Localizable.strings
@@ -46,6 +46,7 @@
 
 "settings.menu_bar.show_icon" = "显示图标";
 "settings.menu_bar.show_date" = "显示日期";
+"settings.menu_bar.show_lunar_date" = "显示农历日期";
 "settings.menu_bar.date_format_custom" = "自定义";
 
 //"settings.menu_bar.background" = "Background";
@@ -66,6 +67,9 @@
 "settings.calendar" = "日历";
 "settings.calendar.show_month_outline" = "显示月份轮廓";
 "settings.calendar.show_week_numbers" = "显示周数";
+"settings.calendar.show_lunar_calendar" = "显示农历";
+"settings.calendar.show_mainland_holidays" = "显示节假日";
+"settings.calendar.show_solar_terms" = "显示节气";
 "settings.calendar.preserve_selected_date" = "隐藏时保留所选日期";
 "settings.calendar.show_declined_events" = "显示拒绝的日程";
 "settings.calendar.show_declined_events_tooltip" = "此功能需在原生日历应用中同样启用。";

--- a/Calendr/Assets/zh-Hant-TW.lproj/Localizable.strings
+++ b/Calendr/Assets/zh-Hant-TW.lproj/Localizable.strings
@@ -46,6 +46,7 @@
 
 "settings.menu_bar.show_icon" = "顯示圖示";
 "settings.menu_bar.show_date" = "顯示日期";
+"settings.menu_bar.show_lunar_date" = "顯示農曆日期";
 "settings.menu_bar.date_format_custom" = "自訂";
 
 //"settings.menu_bar.background" = "Background";
@@ -66,6 +67,9 @@
 "settings.calendar" = "行事曆";
 //"settings.calendar.show_month_outline" = "Show month outline";
 "settings.calendar.show_week_numbers" = "顯示週數";
+"settings.calendar.show_lunar_calendar" = "顯示農曆";
+"settings.calendar.show_mainland_holidays" = "顯示節假日";
+"settings.calendar.show_solar_terms" = "顯示節氣";
 "settings.calendar.preserve_selected_date" = "隱藏時保留選定日期";
 "settings.calendar.show_declined_events" = "顯示已拒絕的事件";
 "settings.calendar.show_declined_events_tooltip" = "這僅在本機行事曆應用程式中也啟用時有效。";

--- a/Calendr/Calendar/CalendarCellView.swift
+++ b/Calendr/Calendar/CalendarCellView.swift
@@ -20,8 +20,13 @@ class CalendarCellView: NSView {
     private let textScaling: Observable<Double>
 
     private let label: Label
+    private let lunarLabel: Label
     private let eventsStackView = NSStackView()
     private let borderLayer = CALayer()
+    private let restDayLayer = CALayer()
+    private var contentStackView: NSStackView!
+    private var contentTopConstraint: NSLayoutConstraint!
+    private var contentCenterYConstraint: NSLayoutConstraint!
 
     init(
         viewModel: Observable<CalendarCellViewModel>,
@@ -40,6 +45,7 @@ class CalendarCellView: NSView {
         self.textScaling = textScaling
 
         label = Label(font: .systemFont(ofSize: Constants.fontSize), scaling: textScaling)
+        lunarLabel = Label(font: .systemFont(ofSize: Constants.lunarFontSize), scaling: textScaling)
 
         super.init(frame: .zero)
 
@@ -53,11 +59,23 @@ class CalendarCellView: NSView {
         forAutoLayout()
 
         wantsLayer = true
+        clipsToBounds = false
+        restDayLayer.cornerRadius = Constants.cornerRadius
+        layer!.addSublayer(restDayLayer)
         borderLayer.cornerRadius = Constants.cornerRadius
         layer!.addSublayer(borderLayer)
 
         label.alignment = .center
         label.textColor = .headerTextColor
+        label.setContentHuggingPriority(.required, for: .vertical)
+        label.setContentCompressionResistancePriority(.required, for: .vertical)
+
+        lunarLabel.alignment = .center
+        lunarLabel.textColor = .secondaryLabelColor
+        lunarLabel.maximumNumberOfLines = 1
+        lunarLabel.lineBreakMode = .byClipping
+        lunarLabel.setContentHuggingPriority(.required, for: .vertical)
+        lunarLabel.setContentCompressionResistancePriority(.required, for: .vertical)
 
         let eventsContainer = NSView()
         eventsContainer.addSubview(eventsStackView)
@@ -68,13 +86,46 @@ class CalendarCellView: NSView {
         eventsStackView.center(in: eventsContainer, orientation: .horizontal)
         eventsStackView.width(lessThanOrEqualTo: eventsContainer)
 
-        let contentStackView = NSStackView(views: [label, eventsContainer])
+        let stack = NSStackView(views: [label, lunarLabel, eventsContainer])
             .with(orientation: .vertical)
-            .with(spacing: 2)
+            .with(alignment: .centerX)
+            .with(spacing: 0)
 
-        addSubview(contentStackView)
+        contentStackView = stack
+        addSubview(stack)
+        stack.clipsToBounds = false
 
-        contentStackView.center(in: self)
+        stack.center(in: self, orientation: .horizontal)
+        stack.width(lessThanOrEqualTo: self)
+        contentTopConstraint = stack.top(equalTo: self, constant: Constants.contentInset)
+        contentTopConstraint.isActive = false
+        contentCenterYConstraint = stack.center(in: self, orientation: .vertical)
+    }
+
+    private func applySecondaryLineLayout(_ expanded: Bool) {
+        if expanded {
+            contentCenterYConstraint.isActive = false
+            contentTopConstraint.isActive = true
+        } else {
+            contentTopConstraint.isActive = false
+            contentCenterYConstraint.isActive = true
+        }
+        contentStackView.spacing = expanded ? Constants.contentSpacing : 0
+        eventsStackView.spacing = expanded ? Constants.contentSpacing : 2
+        contentStackView.setHuggingPriority(expanded ? .required : .defaultLow, for: .vertical)
+        needsLayout = true
+        layoutSubtreeIfNeeded()
+        updateBorderLayers()
+    }
+
+    private func updateBorderLayers() {
+        borderLayer.frame = bounds
+        restDayLayer.frame = bounds.insetBy(dx: 1, dy: 1)
+    }
+
+    override func layout() {
+        super.layout()
+        updateBorderLayers()
     }
 
     private func setUpBindings() {
@@ -96,6 +147,78 @@ class CalendarCellView: NSView {
             .map(\.alpha)
             .distinctUntilChanged()
             .bind(to: label.rx.alpha)
+            .disposed(by: disposeBag)
+
+        viewModel
+            .map(\.usesSecondaryLine)
+            .distinctUntilChanged()
+            .bind { [weak self] in
+                self?.applySecondaryLineLayout($0)
+            }
+            .disposed(by: disposeBag)
+
+        viewModel
+            .map { vm -> String in
+                if let text = vm.lunarText { return text }
+                return vm.usesSecondaryLine ? " " : ""
+            }
+            .distinctUntilChanged()
+            .bind(to: lunarLabel.rx.text)
+            .disposed(by: disposeBag)
+
+        viewModel
+            .map(\.isLunarMonthStart)
+            .distinctUntilChanged()
+            .bind { [lunarLabel] isMonthStart in
+                lunarLabel.font = .systemFont(
+                    ofSize: Constants.lunarFontSize,
+                    weight: isMonthStart ? .semibold : .regular
+                )
+            }
+            .disposed(by: disposeBag)
+
+        viewModel
+            .map { vm in !vm.usesSecondaryLine }
+            .distinctUntilChanged()
+            .bind(to: lunarLabel.rx.isHidden)
+            .disposed(by: disposeBag)
+
+        viewModel
+            .map { vm -> CGFloat in
+                guard vm.usesSecondaryLine else { return 0 }
+                guard vm.lunarText != nil else { return 0 }
+                return vm.alpha * (vm.isStatutoryRestDay || vm.holidayName != nil ? 0.9 : 0.7)
+            }
+            .distinctUntilChanged()
+            .bind(to: lunarLabel.rx.alpha)
+            .disposed(by: disposeBag)
+
+        viewModel
+            .map { vm -> NSColor in
+                if vm.isStatutoryRestDay {
+                    return NSColor.systemRed.withAlphaComponent(0.8)
+                }
+                if vm.isSolarTermDay {
+                    return NSColor.systemBrown.withAlphaComponent(0.85)
+                }
+                if vm.holidayName != nil {
+                    return NSColor.systemRed.withAlphaComponent(0.65)
+                }
+                return .secondaryLabelColor
+            }
+            .bind { [lunarLabel] in
+                lunarLabel.textColor = $0
+            }
+            .disposed(by: disposeBag)
+
+        viewModel
+            .map(\.isStatutoryRestDay)
+            .distinctUntilChanged()
+            .bind { [restDayLayer] isRest in
+                restDayLayer.backgroundColor = isRest
+                    ? NSColor.systemRed.withAlphaComponent(0.08).cgColor
+                    : nil
+            }
             .disposed(by: disposeBag)
 
         viewModel
@@ -169,7 +292,7 @@ class CalendarCellView: NSView {
 
     override func updateLayer() {
         super.updateLayer()
-        borderLayer.frame = bounds
+        updateBorderLayers()
     }
 
     override func acceptsFirstMouse(for event: NSEvent?) -> Bool {
@@ -234,7 +357,11 @@ private func makeEventDot(color: NSColor, scaling: Double) -> NSView {
 private enum Constants {
 
     static let fontSize: CGFloat = 12
+    static let lunarFontSize: CGFloat = 9
     static let eventDotSize: CGFloat = 3
+    static let contentSpacing: CGFloat = 1
+    static let contentInset: CGFloat = 2
+    static let bottomInset: CGFloat = 2
 
     static let borderWidth: CGFloat = 2
     static let cornerRadius: CGFloat = 5

--- a/Calendr/Calendar/CalendarCellViewModel.swift
+++ b/Calendr/Calendar/CalendarCellViewModel.swift
@@ -21,12 +21,43 @@ struct CalendarCellViewModel: Equatable {
     let events: [EventModel]
     let dotsStyle: EventDotsStyle
     let calendar: Calendar
+    let showLunarCalendar: Bool
+    let showMainlandHolidays: Bool
+    let showSolarTerms: Bool
 }
 
 extension CalendarCellViewModel {
 
     var text: String {
         "\(calendar.component(.day, from: date))"
+    }
+
+    var lunarDate: ChineseLunarDate? {
+        guard showLunarCalendar else { return nil }
+        return chineseLunarDate(from: date, calendar: calendar)
+    }
+
+    var usesSecondaryLine: Bool { showLunarCalendar || showMainlandHolidays || showSolarTerms }
+
+    var holidayName: String? {
+        guard showMainlandHolidays else { return nil }
+        return chineseMainlandHolidayName(from: events, date: date, calendar: calendar)
+    }
+
+    var solarTermText: String? {
+        guard showSolarTerms else { return nil }
+        return solarTermName(on: date, calendar: calendar)
+    }
+
+    var isSolarTermDay: Bool { holidayName == nil && solarTermText != nil }
+
+    var lunarText: String? { holidayName ?? solarTermText ?? lunarDate?.text }
+
+    var isLunarMonthStart: Bool { holidayName != nil || lunarDate?.isMonthStart == true }
+
+    var isStatutoryRestDay: Bool {
+        guard showMainlandHolidays else { return false }
+        return isChineseMainlandRestDay(from: events, date: date, calendar: calendar)
     }
 
     var alpha: CGFloat {

--- a/Calendr/Calendar/CalendarView.swift
+++ b/Calendr/Calendar/CalendarView.swift
@@ -99,10 +99,10 @@ class CalendarView: NSView {
 
         guard let gridView else { return }
 
-        viewModel.cellSize
-            .bind { [gridView] cellSize in
+        Observable.combineLatest(viewModel.cellSize, viewModel.cellHeight)
+            .bind { [gridView] cellSize, cellHeight in
                 for row in 0..<gridView.numberOfRows {
-                    gridView.row(at: row).height = cellSize
+                    gridView.row(at: row).height = cellHeight
                     /// skip week number column, because it has dynamic width
                     for col in 1..<gridView.numberOfColumns {
                         gridView.column(at: col).width = cellSize
@@ -126,10 +126,11 @@ class CalendarView: NSView {
         Observable.combineLatest(
             viewModel.weekNumbersWidth,
             viewModel.weekDays,
-            viewModel.cellSize
+            viewModel.cellSize,
+            viewModel.cellHeight
         )
         .repeat(when: rx.updateLayer)
-        .map { offset, weekDays, cellSize -> [CALayer] in
+        .map { offset, weekDays, cellSize, cellHeight -> [CALayer] in
 
             let weekends = weekDays
                 .enumerated()
@@ -142,7 +143,7 @@ class CalendarView: NSView {
                     x: offset + CGFloat(range.startIndex) * cellSize,
                     y: 0,
                     width: CGFloat(range.count) * cellSize,
-                    height: CGFloat(weekCount) * cellSize
+                    height: CGFloat(weekCount) * cellHeight
                 )
                 layer.backgroundColor = Colors.weekendBackground
                 layer.cornerRadius = Constants.cornerRadius

--- a/Calendr/Calendar/CalendarViewModel.swift
+++ b/Calendr/Calendar/CalendarViewModel.swift
@@ -14,12 +14,14 @@ class CalendarViewModel {
     let eventListObservable: Observable<DateEvents>
 
     let title: Observable<String>
+    let yearTitle: Observable<String>
     let weekCount: Observable<Int>
     let weekDays: Observable<[WeekDay]>
     let weekNumbers: Observable<[Int]?>
     let calendarScaling: Observable<Double>
     let textScaling: Observable<Double>
     let cellSize: Observable<Double>
+    let cellHeight: Observable<Double>
     let weekNumbersWidth: Observable<Double>
     let showMonthOutline: Observable<Bool>
 
@@ -38,16 +40,32 @@ class CalendarViewModel {
             .startWith(dateProvider.calendar)
             .share(replay: 1)
 
-        let dateFormatterObservable = calendarUpdated
-            .map { calendar in
-                DateFormatter(format: "MMM yyyy", calendar: calendar).with(context: .beginningOfSentence)
-            }
-            .share(replay: 1)
-
-        title = Observable.combineLatest(
-            dateFormatterObservable, dateObservable
+        let lunarTitleParts = Observable.combineLatest(
+            dateObservable, calendarUpdated, settings.showLunarCalendar
         )
-        .map { $0.string(from: $1) }
+        .share(replay: 1)
+
+        title = lunarTitleParts
+        .map { date, calendar, showLunar -> String in
+            if showLunar {
+                let monthDay = DateFormatter(format: "M月d日", calendar: calendar).string(from: date)
+                if let lunar = chineseLunarFullDateString(from: date, calendar: calendar), !lunar.isEmpty {
+                    return monthDay + " " + lunar
+                }
+                return monthDay
+            }
+            return DateFormatter(format: "MMM", calendar: calendar)
+                .with(context: .beginningOfSentence)
+                .string(from: date)
+        }
+        .distinctUntilChanged()
+        .share(replay: 1)
+
+        yearTitle = lunarTitleParts
+        .map { date, calendar, showLunar -> String in
+            let format = showLunar ? "yyyy年" : "yyyy"
+            return DateFormatter(format: format, calendar: calendar).string(from: date)
+        }
         .distinctUntilChanged()
         .share(replay: 1)
 
@@ -84,9 +102,12 @@ class CalendarViewModel {
                 debouncedWeekCount,
                 dateRangeObservable,
                 calendarUpdated,
-                settings.eventDotsStyle
+                settings.eventDotsStyle,
+                settings.showLunarCalendar,
+                settings.showMainlandHolidays,
+                settings.showSolarTerms
             )
-            .map { weeksCount, month, calendar, dotsStyle -> [CalendarCellViewModel] in
+            .map { weeksCount, month, calendar, dotsStyle, showLunar, showHolidays, showTerms -> [CalendarCellViewModel] in
 
                 let monthStartWeekDay = calendar.component(.weekday, from: month.start)
 
@@ -108,7 +129,10 @@ class CalendarViewModel {
                         isHovered: false,
                         events: [],
                         dotsStyle: dotsStyle,
-                        calendar: calendar
+                        calendar: calendar,
+                        showLunarCalendar: showLunar,
+                        showMainlandHolidays: showHolidays,
+                        showSolarTerms: showTerms
                     )
                 }
             }
@@ -300,8 +324,29 @@ class CalendarViewModel {
             .map(*)
             .share(replay: 1)
 
-        cellSize = calendarScaling
-            .map { Constants.cellSize * $0 + 10 * ($0 - 1) }
+        let usesSecondaryLine = Observable.combineLatest(
+            settings.showLunarCalendar,
+            settings.showMainlandHolidays,
+            settings.showSolarTerms
+        )
+        .map { $0 || $1 || $2 }
+        .share(replay: 1)
+
+        cellSize = Observable
+            .combineLatest(calendarScaling, usesSecondaryLine)
+            .map { scale, expanded -> Double in
+                let base = Constants.cellSize * scale + 10 * (scale - 1)
+                return expanded ? base + Constants.lunarCellWidthExtra * scale : base
+            }
+            .distinctUntilChanged()
+            .share(replay: 1)
+
+        cellHeight = Observable
+            .combineLatest(calendarScaling, usesSecondaryLine)
+            .map { scale, expanded -> Double in
+                let base = Constants.cellSize * scale + 10 * (scale - 1)
+                return expanded ? base + Constants.lunarCellExtra * scale : base
+            }
             .distinctUntilChanged()
             .share(replay: 1)
 
@@ -364,7 +409,10 @@ private extension CalendarCellViewModel {
             isHovered: isHovered ?? self.isHovered,
             events: events ?? self.events,
             dotsStyle: dotsStyle,
-            calendar: calendar ?? self.calendar
+            calendar: calendar ?? self.calendar,
+            showLunarCalendar: showLunarCalendar,
+            showMainlandHolidays: showMainlandHolidays,
+            showSolarTerms: showSolarTerms
         )
     }
 }
@@ -372,6 +420,8 @@ private extension CalendarCellViewModel {
 private enum Constants {
 
     static let cellSize: CGFloat = 25
+    static let lunarCellWidthExtra: CGFloat = 6
+    static let lunarCellExtra: CGFloat = 13
     static let weekNumberCellRatio: CGFloat = 0.85
     static let maxSearchResults: Int = 12
 }

--- a/Calendr/Constants/Strings.generated.swift
+++ b/Calendr/Constants/Strings.generated.swift
@@ -287,6 +287,12 @@ internal enum Strings {
       internal static let showMonthOutline = Strings.tr("Localizable", "settings.calendar.show_month_outline", fallback: "Show month outline")
       /// Show week numbers
       internal static let showWeekNumbers = Strings.tr("Localizable", "settings.calendar.show_week_numbers", fallback: "Show week numbers")
+      /// Show Chinese lunar dates
+      internal static let showLunarCalendar = Strings.tr("Localizable", "settings.calendar.show_lunar_calendar", fallback: "Show Chinese lunar dates")
+      /// Show mainland holidays
+      internal static let showMainlandHolidays = Strings.tr("Localizable", "settings.calendar.show_mainland_holidays", fallback: "Show mainland holidays")
+      /// Show solar terms
+      internal static let showSolarTerms = Strings.tr("Localizable", "settings.calendar.show_solar_terms", fallback: "Show solar terms")
       /// Visible weeks
       internal static let weekCount = Strings.tr("Localizable", "settings.calendar.week_count", fallback: "Visible weeks")
       internal enum EventDots {
@@ -377,6 +383,8 @@ internal enum Strings {
       internal static let openOnHover = Strings.tr("Localizable", "settings.menu_bar.open_on_hover", fallback: "Open on mouse hover")
       /// Show date
       internal static let showDate = Strings.tr("Localizable", "settings.menu_bar.show_date", fallback: "Show date")
+      /// Show lunar date
+      internal static let showLunarDate = Strings.tr("Localizable", "settings.menu_bar.show_lunar_date", fallback: "Show lunar date")
       /// Show icon
       internal static let showIcon = Strings.tr("Localizable", "settings.menu_bar.show_icon", fallback: "Show icon")
       internal enum Background {

--- a/Calendr/MenuBar/StatusItemViewModel.swift
+++ b/Calendr/MenuBar/StatusItemViewModel.swift
@@ -70,11 +70,12 @@ class StatusItemViewModel {
         let dateTextObservable = Observable
             .combineLatest(
                 settings.showStatusItemDate,
+                settings.showStatusItemLunarDate,
                 settings.statusItemDateStyle,
                 settings.statusItemDateFormat
             )
             .repeat(when: localeChangeObservable)
-            .flatMapLatest { showDate, style, format -> Observable<String> in
+            .flatMapLatest { showDate, showLunar, style, format -> Observable<String> in
 
                 guard showDate else { return .just("") }
 
@@ -84,7 +85,7 @@ class StatusItemViewModel {
                 let ticker = Observable<Int>.interval(.seconds(1), scheduler: scheduler).void().startWith(())
 
                 return ticker.map {
-                    let text = if style.isCustom {
+                    var text = if style.isCustom {
                         DateFormatRenderer.render(
                             format: format,
                             date: dateProvider.now,
@@ -92,6 +93,9 @@ class StatusItemViewModel {
                         )
                     } else {
                         formatter.string(from: dateProvider.now)
+                    }
+                    if showLunar, let lunar = chineseLunarFullDateString(from: dateProvider.now, calendar: dateProvider.calendar) {
+                        text = text.isEmpty ? lunar : text + " " + lunar
                     }
                     return text.isEmpty ? "???" : text
                 }

--- a/Calendr/Mocks/MockCalendarSettings.swift
+++ b/Calendr/Mocks/MockCalendarSettings.swift
@@ -55,6 +55,10 @@ class MockCalendarSettings: CalendarSettings {
     let textScaling: Observable<Double>
     let textScalingObserver: AnyObserver<Double>
 
+    let showLunarCalendar: Observable<Bool>
+    let showMainlandHolidays: Observable<Bool>
+    let showSolarTerms: Observable<Bool>
+
     init(
         calendarScaling: Double = 1,
         textScaling: Double = 1,
@@ -89,6 +93,9 @@ class MockCalendarSettings: CalendarSettings {
 
         self.showMonthOutline = .just(showMonthOutline)
         defaultCalendarApp = .just(.calendar)
+        showLunarCalendar = .just(true)
+        showMainlandHolidays = .just(true)
+        showSolarTerms = .just(true)
     }
 }
 

--- a/Calendr/Mocks/MockStatusItemSettings.swift
+++ b/Calendr/Mocks/MockStatusItemSettings.swift
@@ -21,6 +21,7 @@ class MockStatusItemSettings: StatusItemSettings {
 
     let showStatusItemIcon: Observable<Bool>
     let showStatusItemDate: Observable<Bool>
+    let showStatusItemLunarDate: Observable<Bool>
     let statusItemBackgroundStyle: Observable<StatusItemBackgroundStyle>
     let statusItemIconStyle: Observable<StatusItemIconStyle>
     let statusItemDateStyle: Observable<StatusItemDateStyle>
@@ -42,6 +43,7 @@ class MockStatusItemSettings: StatusItemSettings {
     ) {
         (showStatusItemIcon, toggleIcon) = BehaviorSubject.pipe(value: showIcon)
         (showStatusItemDate, toggleDate) = BehaviorSubject.pipe(value: showDate)
+        showStatusItemLunarDate = .just(true)
         (statusItemBackgroundStyle, statusItemBackgroundStyleObserver) = BehaviorSubject.pipe(value: backgroundStyle)
         (statusItemIconStyle, statusItemIconStyleObserver) = BehaviorSubject.pipe(value: iconStyle)
         (statusItemDateStyle, statusItemDateStyleObserver) = BehaviorSubject.pipe(value: dateStyle)

--- a/Calendr/Settings/GeneralSettingsViewController.swift
+++ b/Calendr/Settings/GeneralSettingsViewController.swift
@@ -19,6 +19,7 @@ class GeneralSettingsViewController: NSViewController, SettingsUI {
     private let launchAgentCheckbox = Checkbox(title: Strings.Settings.MenuBar.launchAgent)
     private let showMenuBarIconCheckbox = Checkbox(title: Strings.Settings.MenuBar.showIcon)
     private let showMenuBarDateCheckbox = Checkbox(title: Strings.Settings.MenuBar.showDate)
+    private let showMenuBarLunarDateCheckbox = Checkbox(title: Strings.Settings.MenuBar.showLunarDate)
     private let statusItemBackgroundLabel = Label(text: Strings.Settings.MenuBar.background)
     private let statusItemBackgroundDropdown = Dropdown()
     private let openOnHoverCheckbox = Checkbox(title: Strings.Settings.MenuBar.openOnHover)
@@ -46,6 +47,9 @@ class GeneralSettingsViewController: NSViewController, SettingsUI {
     private let weekCountStepper = NSStepper()
     private let showMonthOutlineCheckbox = Checkbox(title: Strings.Settings.Calendar.showMonthOutline)
     private let showWeekNumbersCheckbox = Checkbox(title: Strings.Settings.Calendar.showWeekNumbers)
+    private let showLunarCalendarCheckbox = Checkbox(title: Strings.Settings.Calendar.showLunarCalendar)
+    private let showMainlandHolidaysCheckbox = Checkbox(title: Strings.Settings.Calendar.showMainlandHolidays)
+    private let showSolarTermsCheckbox = Checkbox(title: Strings.Settings.Calendar.showSolarTerms)
     private let showDeclinedEventsCheckbox = Checkbox(title: Strings.Settings.Calendar.showDeclinedEvents)
     private let preserveSelectedDateCheckbox = Checkbox(title: Strings.Settings.Calendar.preserveSelectedDate)
     private let dateHoverOptionCheckbox = Checkbox(title: Strings.Settings.Calendar.dateHoverOption)
@@ -155,6 +159,7 @@ class GeneralSettingsViewController: NSViewController, SettingsUI {
             openOnHoverCheckbox,
             iconStyle,
             showMenuBarDateCheckbox,
+            showMenuBarLunarDateCheckbox,
             dateFormat,
             NSStackView(views: [statusItemBackgroundLabel, statusItemBackgroundDropdown]),
             .spacer
@@ -229,6 +234,9 @@ class GeneralSettingsViewController: NSViewController, SettingsUI {
             .dummy,
             showMonthOutlineCheckbox,
             showWeekNumbersCheckbox,
+            showLunarCalendarCheckbox,
+            showMainlandHolidaysCheckbox,
+            showSolarTermsCheckbox,
             NSStackView(views: [showDeclinedEventsCheckbox, showDeclinedEventsTooltip]),
             preserveSelectedDateCheckbox,
             dateHoverOptionCheckbox,
@@ -317,6 +325,17 @@ class GeneralSettingsViewController: NSViewController, SettingsUI {
             observer: viewModel.toggleStatusItemDate
         )
         .disposed(by: disposeBag)
+
+        bind(
+            control: showMenuBarLunarDateCheckbox,
+            observable: viewModel.showStatusItemLunarDate,
+            observer: viewModel.toggleStatusItemLunarDate
+        )
+        .disposed(by: disposeBag)
+
+        viewModel.showStatusItemDate
+            .bind(to: showMenuBarLunarDateCheckbox.rx.isEnabled)
+            .disposed(by: disposeBag)
 
         setUpDateFormat()
 
@@ -616,6 +635,27 @@ class GeneralSettingsViewController: NSViewController, SettingsUI {
             control: showWeekNumbersCheckbox,
             observable: viewModel.showWeekNumbers,
             observer: viewModel.toggleWeekNumbers
+        )
+        .disposed(by: disposeBag)
+
+        bind(
+            control: showLunarCalendarCheckbox,
+            observable: viewModel.showLunarCalendar,
+            observer: viewModel.toggleLunarCalendar
+        )
+        .disposed(by: disposeBag)
+
+        bind(
+            control: showMainlandHolidaysCheckbox,
+            observable: viewModel.showMainlandHolidays,
+            observer: viewModel.toggleMainlandHolidays
+        )
+        .disposed(by: disposeBag)
+
+        bind(
+            control: showSolarTermsCheckbox,
+            observable: viewModel.showSolarTerms,
+            observer: viewModel.toggleSolarTerms
         )
         .disposed(by: disposeBag)
 

--- a/Calendr/Settings/LocalStoragePrefs.swift
+++ b/Calendr/Settings/LocalStoragePrefs.swift
@@ -17,6 +17,7 @@ enum Prefs {
     static let statusItemDateEnabled = "status_item_date_enabled"
     static let statusItemDateStyle = "status_item_date_style"
     static let statusItemDateFormat = "status_item_date_format"
+    static let statusItemLunarDateEnabled = "status_item_lunar_date_enabled"
     static let statusItemBackgroundStyle = "status_item_background_style"
     static let legacyStatusItemBackgroundEnabled = "status_item_background_enabled"
     static let statusItemTextScaling = "status_item_text_scaling"
@@ -52,6 +53,9 @@ enum Prefs {
     static let defaultCalendarApp = "default_calendar_app"
     static let calendarTextScaling = "calendar_text_scaling"
     static let eventDotsStyle = "event_dots_style"
+    static let showLunarCalendar = "show_lunar_calendar"
+    static let showMainlandHolidays = "show_mainland_holidays"
+    static let showSolarTerms = "show_solar_terms"
 
     // Event Details
     static let showMap = "show_map"
@@ -105,6 +109,7 @@ func registerDefaultPrefs(
         Prefs.statusItemDateEnabled: true,
         Prefs.statusItemDateStyle: StatusItemDateStyle.short.rawValue,
         Prefs.statusItemDateFormat: AppConstants.defaultCustomDateFormat,
+        Prefs.statusItemLunarDateEnabled: true,
         Prefs.statusItemBackgroundStyle: StatusItemBackgroundStyle.transparent.rawValue,
         Prefs.statusItemTextScaling: 1.2,
         Prefs.statusItemOpenOnHover: false,
@@ -138,6 +143,9 @@ func registerDefaultPrefs(
         Prefs.calendarAppViewMode: CalendarViewMode.month.rawValue,
         Prefs.defaultCalendarApp: CalendarApp.calendar.rawValue,
         Prefs.calendarTextScaling: 1,
+        Prefs.showLunarCalendar: true,
+        Prefs.showMainlandHolidays: true,
+        Prefs.showSolarTerms: true,
 
         // Event Details
         Prefs.showMap: true,
@@ -221,6 +229,11 @@ extension LocalStorageProvider {
     @objc dynamic var statusItemDateFormat: String {
         get { string(forKey: Prefs.statusItemDateFormat) ?? "" }
         set { set(newValue, forKey: Prefs.statusItemDateFormat) }
+    }
+
+    @objc dynamic var statusItemLunarDateEnabled: Bool {
+        get { bool(forKey: Prefs.statusItemLunarDateEnabled) }
+        set { set(newValue, forKey: Prefs.statusItemLunarDateEnabled) }
     }
 
     @objc dynamic var statusItemBackgroundStyle: String {
@@ -370,6 +383,21 @@ extension LocalStorageProvider {
     @objc dynamic var calendarTextScaling: Double {
         get { double(forKey: Prefs.calendarTextScaling) }
         set { set(newValue, forKey: Prefs.calendarTextScaling) }
+    }
+
+    @objc dynamic var showLunarCalendar: Bool {
+        get { bool(forKey: Prefs.showLunarCalendar) }
+        set { set(newValue, forKey: Prefs.showLunarCalendar) }
+    }
+
+    @objc dynamic var showMainlandHolidays: Bool {
+        get { bool(forKey: Prefs.showMainlandHolidays) }
+        set { set(newValue, forKey: Prefs.showMainlandHolidays) }
+    }
+
+    @objc dynamic var showSolarTerms: Bool {
+        get { bool(forKey: Prefs.showSolarTerms) }
+        set { set(newValue, forKey: Prefs.showSolarTerms) }
     }
 
     // Event Details

--- a/Calendr/Settings/SettingsViewModel.swift
+++ b/Calendr/Settings/SettingsViewModel.swift
@@ -11,6 +11,7 @@ import RxSwift
 protocol StatusItemSettings {
     var showStatusItemIcon: Observable<Bool> { get }
     var showStatusItemDate: Observable<Bool> { get }
+    var showStatusItemLunarDate: Observable<Bool> { get }
     var statusItemBackgroundStyle: Observable<StatusItemBackgroundStyle> { get }
     var openOnHover: Observable<Bool> { get }
     var statusItemIconStyle: Observable<StatusItemIconStyle> { get }
@@ -37,6 +38,9 @@ protocol CalendarSettings {
     var defaultCalendarApp: Observable<CalendarApp> { get }
     var futureEventsDays: Observable<Int> { get }
     var showAllDayEvents: Observable<Bool> { get }
+    var showLunarCalendar: Observable<Bool> { get }
+    var showMainlandHolidays: Observable<Bool> { get }
+    var showSolarTerms: Observable<Bool> { get }
 }
 
 protocol AppearanceSettings {
@@ -111,6 +115,7 @@ class SettingsViewModel:
     let toggleLaunchAgent: AnyObserver<Bool>
     let toggleStatusItemIcon: AnyObserver<Bool>
     let toggleStatusItemDate: AnyObserver<Bool>
+    let toggleStatusItemLunarDate: AnyObserver<Bool>
     let statusItemBackgroundStyleObserver: AnyObserver<StatusItemBackgroundStyle>
     let toggleOpenOnHover: AnyObserver<Bool>
     let statusItemTextScalingObserver: AnyObserver<Double>
@@ -135,6 +140,9 @@ class SettingsViewModel:
     let toggleHighlightedWeekday: AnyObserver<Int>
     let toggleMonthOutline: AnyObserver<Bool>
     let toggleWeekNumbers: AnyObserver<Bool>
+    let toggleLunarCalendar: AnyObserver<Bool>
+    let toggleMainlandHolidays: AnyObserver<Bool>
+    let toggleSolarTerms: AnyObserver<Bool>
     let toggleDeclinedEvents: AnyObserver<Bool>
     let togglePreserveSelectedDate: AnyObserver<Bool>
     let toggleDateHoverOption: AnyObserver<Bool>
@@ -162,6 +170,7 @@ class SettingsViewModel:
     let launchAgent: Observable<Bool>
     let showStatusItemIcon: Observable<Bool>
     let showStatusItemDate: Observable<Bool>
+    let showStatusItemLunarDate: Observable<Bool>
     let statusItemBackgroundStyle: Observable<StatusItemBackgroundStyle>
     let openOnHover: Observable<Bool>
     let statusItemIconStyle: Observable<StatusItemIconStyle>
@@ -213,6 +222,9 @@ class SettingsViewModel:
     let eventDotsStyle: Observable<EventDotsStyle>
     let calendarAppViewMode: Observable<CalendarViewMode>
     let defaultCalendarApp: Observable<CalendarApp>
+    let showLunarCalendar: Observable<Bool>
+    let showMainlandHolidays: Observable<Bool>
+    let showSolarTerms: Observable<Bool>
     let appearanceMode: Observable<AppearanceMode>
     let autoCheckForUpdates: Observable<Bool>
 
@@ -282,6 +294,7 @@ class SettingsViewModel:
         toggleLaunchAgent = autoLauncher.rx.observer(for: \.isLaunchAgentEnabled)
         toggleStatusItemIcon = localStorage.rx.observer(for: \.statusItemIconEnabled)
         toggleStatusItemDate = localStorage.rx.observer(for: \.statusItemDateEnabled)
+        toggleStatusItemLunarDate = localStorage.rx.observer(for: \.statusItemLunarDateEnabled)
         statusItemBackgroundStyleObserver = localStorage.rx.observer(for: \.statusItemBackgroundStyle).mapObserver(\.rawValue)
         toggleOpenOnHover = localStorage.rx.observer(for: \.statusItemOpenOnHover)
         statusItemIconStyleObserver = localStorage.rx.observer(for: \.statusItemIconStyle).mapObserver(\.rawValue)
@@ -306,6 +319,9 @@ class SettingsViewModel:
         weekCountObserver = localStorage.rx.observer(for: \.weekCount)
         toggleMonthOutline = localStorage.rx.observer(for: \.showMonthOutline)
         toggleWeekNumbers = localStorage.rx.observer(for: \.showWeekNumbers)
+        toggleLunarCalendar = localStorage.rx.observer(for: \.showLunarCalendar)
+        toggleMainlandHolidays = localStorage.rx.observer(for: \.showMainlandHolidays)
+        toggleSolarTerms = localStorage.rx.observer(for: \.showSolarTerms)
         toggleDeclinedEvents = localStorage.rx.observer(for: \.showDeclinedEvents)
         togglePreserveSelectedDate = localStorage.rx.observer(for: \.preserveSelectedDate)
         toggleDateHoverOption = localStorage.rx.observer(for: \.dateHoverOption)
@@ -335,6 +351,7 @@ class SettingsViewModel:
         openOnHover = localStorage.rx.observe(\.statusItemOpenOnHover)
         showStatusItemIcon = localStorage.rx.observe(\.statusItemIconEnabled)
         showStatusItemDate = localStorage.rx.observe(\.statusItemDateEnabled)
+        showStatusItemLunarDate = localStorage.rx.observe(\.statusItemLunarDateEnabled)
         statusItemBackgroundStyle = localStorage.rx.observe(\.statusItemBackgroundStyle).map { .init(rawValue: $0) ?? .transparent }
         statusItemIconStyle = localStorage.rx.observe(\.statusItemIconStyle).map { .init(rawValue: $0) ?? .calendar }
         statusItemDateStyle = localStorage.rx.observe(\.statusItemDateStyle).map { .init(rawValue: $0) ?? .none }
@@ -377,6 +394,9 @@ class SettingsViewModel:
         eventDotsStyle = localStorage.rx.observe(\.eventDotsStyle).map { .init(rawValue: $0) ?? .none }
         calendarAppViewMode = localStorage.rx.observe(\.calendarAppViewMode).map { .init(rawValue: $0) ?? .month }
         defaultCalendarApp = localStorage.rx.observe(\.defaultCalendarApp).map { .init(rawValue: $0) ?? .calendar }
+        showLunarCalendar = localStorage.rx.observe(\.showLunarCalendar)
+        showMainlandHolidays = localStorage.rx.observe(\.showMainlandHolidays)
+        showSolarTerms = localStorage.rx.observe(\.showSolarTerms)
         appearanceMode = localStorage.rx.observe(\.appearanceMode).map { .init(rawValue: $0) ?? .automatic }
         autoCheckForUpdates = localStorage.rx.observe(\.autoCheckForUpdates)
 

--- a/Calendr/Utils/ChineseHoliday.swift
+++ b/Calendr/Utils/ChineseHoliday.swift
@@ -1,0 +1,194 @@
+//
+//  ChineseHoliday.swift
+//  Calendr
+//
+
+import Foundation
+
+private let statutoryHolidayKeys = ["元旦", "春节", "除夕", "清明", "劳动", "端午", "中秋", "国庆"]
+private let festivalHolidayKeys = ["元宵", "七夕", "重阳", "腊八"]
+private let solarTermNames = [
+    "小寒", "大寒", "立春", "雨水", "惊蛰", "春分", "清明", "谷雨",
+    "立夏", "小满", "芒种", "夏至", "小暑", "大暑",
+    "立秋", "处暑", "白露", "秋分", "寒露", "霜降",
+    "立冬", "小雪", "大雪", "冬至"
+]
+
+private let shanghaiTimeZone = TimeZone(identifier: "Asia/Shanghai") ?? TimeZone(secondsFromGMT: 8 * 3600)!
+
+func isChineseMainlandHolidayCalendar(_ calendar: CalendarModel) -> Bool {
+    let haystack = calendar.title + " " + calendar.account.title
+    if haystack.contains("中国大陆节假日") { return true }
+    if haystack.contains("中国节假日") { return true }
+    if haystack.localizedCaseInsensitiveContains("Holidays in China") { return true }
+    if haystack.localizedCaseInsensitiveContains("China Holidays") { return true }
+    if haystack.contains("节假日") && (haystack.contains("中国") || haystack.contains("大陆")) {
+        return true
+    }
+    return false
+}
+
+func isMainlandMakeupWorkTitle(_ title: String) -> Bool {
+    let text = title.lowercased()
+    if title.contains("上班") || title.contains("补班") || title.contains("调休上班") {
+        return true
+    }
+    if text.contains("working day") || text.contains("workday") || text.contains("work day") {
+        return true
+    }
+    return false
+}
+
+func isSolarTermName(_ title: String) -> Bool {
+    solarTermNames.contains { title.contains($0) } && !title.contains("节")
+}
+
+func shortMainlandHolidayName(from title: String) -> String? {
+    if isMainlandMakeupWorkTitle(title) { return nil }
+    if isSolarTermName(title) { return nil }
+
+    for key in statutoryHolidayKeys + festivalHolidayKeys {
+        if title.contains(key) {
+            return key
+        }
+    }
+
+    if title.contains("休息日") || title.contains("放假") {
+        return "休息"
+    }
+
+    let trimmed = title.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !trimmed.isEmpty else { return nil }
+    if trimmed.count <= 3 { return trimmed }
+    return String(trimmed.prefix(2))
+}
+
+/// Statutory rest windows. Makeup-work Sundays/Saturdays (e.g. 9/20, 10/10 for 国庆) stay out.
+func isStatutoryRestDate(_ key: String, date: Date, calendar: Calendar) -> Bool {
+    var shanghaiCalendar = calendar
+    shanghaiCalendar.timeZone = shanghaiTimeZone
+    let month = shanghaiCalendar.component(.month, from: date)
+    let day = shanghaiCalendar.component(.day, from: date)
+    switch key {
+    case "元旦":
+        return month == 1 && (1...3).contains(day)
+    case "春节", "除夕":
+        return month == 1 || month == 2
+    case "清明":
+        return month == 4 && (3...7).contains(day)
+    case "劳动":
+        return month == 5 && (1...5).contains(day)
+    case "端午":
+        return month == 5 || month == 6
+    case "中秋":
+        return (month == 9 && day >= 22) || (month == 10 && day <= 8)
+    case "国庆":
+        return month == 10 && (1...7).contains(day)
+    default:
+        return true
+    }
+}
+
+func solarTermName(on date: Date, calendar: Calendar) -> String? {
+    var shanghaiCalendar = Calendar(identifier: .gregorian)
+    shanghaiCalendar.timeZone = shanghaiTimeZone
+    let year = shanghaiCalendar.component(.year, from: date)
+    for yearToCheck in [year - 1, year] {
+        for index in solarTermNames.indices {
+            guard let termDate = dateOfSolarTerm(year: yearToCheck, index: index) else { continue }
+            if shanghaiCalendar.isDate(date, inSameDayAs: termDate) {
+                return solarTermNames[index]
+            }
+        }
+    }
+    return nil
+}
+
+func chineseMainlandHolidayName(from events: [EventModel], date: Date, calendar: Calendar) -> String? {
+    for event in events where event.isAllDay && isChineseMainlandHolidayCalendar(event.calendar) {
+        if isMainlandMakeupWorkTitle(event.title) { continue }
+        guard let name = shortMainlandHolidayName(from: event.title) else { continue }
+
+        if statutoryHolidayKeys.contains(name) {
+            if isStatutoryRestDate(name, date: date, calendar: calendar) {
+                return name
+            }
+            continue
+        }
+
+        // One-day festivals (七夕 etc.): EventKit all-day ends next midnight.
+        if calendar.isDate(event.start, inSameDayAs: date) {
+            return name
+        }
+    }
+    return nil
+}
+
+func isChineseMainlandRestDay(from events: [EventModel], date: Date, calendar: Calendar) -> Bool {
+    events.contains { event in
+        guard event.isAllDay,
+              isChineseMainlandHolidayCalendar(event.calendar),
+              !isMainlandMakeupWorkTitle(event.title),
+              !isOnlyQingmingSolarTerm(event.title),
+              let name = shortMainlandHolidayName(from: event.title),
+              statutoryHolidayKeys.contains(name)
+        else { return false }
+        return isStatutoryRestDate(name, date: date, calendar: calendar)
+    }
+}
+
+func isSolarTermOverride(from events: [EventModel], date: Date, calendar: Calendar) -> Bool {
+    if let name = chineseMainlandHolidayName(from: events, date: date, calendar: calendar) {
+        return solarTermNames.contains(name) && !isChineseMainlandRestDay(from: events, date: date, calendar: calendar)
+    }
+    return false
+}
+
+private func isOnlyQingmingSolarTerm(_ title: String) -> Bool {
+    title.contains("清明") && !title.contains("节") && !title.contains("放假") && !title.contains("假")
+}
+
+private func normalizedDegrees(_ value: Double) -> Double {
+    var deg = value.truncatingRemainder(dividingBy: 360)
+    if deg < 0 { deg += 360 }
+    return deg
+}
+
+private func signedAngleDelta(target: Double, actual: Double) -> Double {
+    normalizedDegrees(target - actual + 180) - 180
+}
+
+private func julianDay(from date: Date) -> Double {
+    2440587.5 + date.timeIntervalSince1970 / 86_400
+}
+
+/// Apparent geocentric ecliptic longitude of the Sun, Meeus ch. 25 (low accuracy).
+private func sunApparentLongitude(julianDay jd: Double) -> Double {
+    let T = (jd - 2_451_545.0) / 36_525.0
+    let L0 = 280.46646 + 36000.76983 * T + 0.0003032 * T * T
+    let M = 357.52911 + 35999.05029 * T - 0.0001537 * T * T
+    let Mr = M * .pi / 180
+    let C = (1.914602 - 0.004817 * T - 0.000014 * T * T) * sin(Mr)
+        + (0.019993 - 0.000101 * T) * sin(2 * Mr)
+        + 0.000289 * sin(3 * Mr)
+    let omega = 125.04 - 1934.136 * T
+    return normalizedDegrees(L0 + C - 0.00569 - 0.00478 * sin(omega * .pi / 180))
+}
+
+private func dateOfSolarTerm(year: Int, index: Int) -> Date? {
+    guard solarTermNames.indices.contains(index) else { return nil }
+    let target = normalizedDegrees(285 + 15 * Double(index))
+    var utc = Calendar(identifier: .gregorian)
+    utc.timeZone = TimeZone(secondsFromGMT: 0)!
+    guard var date = utc.date(from: DateComponents(year: year, month: 1, day: 1, hour: 0)) else {
+        return nil
+    }
+    let dayOfYear = ((target + 80).truncatingRemainder(dividingBy: 360)) / 0.985647
+    date = date.addingTimeInterval((dayOfYear - 2) * 86_400)
+    for _ in 0..<25 {
+        let lon = sunApparentLongitude(julianDay: julianDay(from: date))
+        let diff = signedAngleDelta(target: target, actual: lon)
+        date = date.addingTimeInterval(diff * 86_400 / 0.985647)
+    }
+    return date
+}

--- a/Calendr/Utils/ChineseLunarCalendar.swift
+++ b/Calendr/Utils/ChineseLunarCalendar.swift
@@ -1,0 +1,95 @@
+//
+//  ChineseLunarCalendar.swift
+//  Calendr
+//
+//  Created by Paker on 28/08/2026.
+//
+
+import Foundation
+
+/// Format a Gregorian date as a Chinese lunar date string.
+/// Returns the lunar day in Chinese numerals (初一、初二、etc.) or month name (正月、二月、etc.) on the first day of the lunar month.
+/// Leap months are marked with 闰 prefix.
+struct ChineseLunarDate {
+    let text: String
+    let fullText: String
+    let isMonthStart: Bool
+}
+
+func chineseLunarDate(from date: Date, calendar gregorianCalendar: Calendar) -> ChineseLunarDate? {
+    let chineseCalendar = Calendar(identifier: .chinese)
+
+    let components = chineseCalendar.dateComponents([.year, .month, .day, .isLeapMonth], from: date)
+
+    guard let month = components.month, let day = components.day else {
+        return nil
+    }
+
+    let isLeapMonth = components.isLeapMonth ?? false
+    let monthName = chineseMonthName(month: month, isLeapMonth: isLeapMonth)
+    let dayName = chineseDayName(day: day)
+
+    if day == 1 {
+        return ChineseLunarDate(text: monthName, fullText: monthName + dayName, isMonthStart: true)
+    }
+
+    return ChineseLunarDate(text: dayName, fullText: monthName + dayName, isMonthStart: false)
+}
+
+func chineseLunarDateString(from date: Date, calendar gregorianCalendar: Calendar) -> String? {
+    chineseLunarDate(from: date, calendar: gregorianCalendar)?.text
+}
+
+func chineseLunarFullDateString(from date: Date, calendar gregorianCalendar: Calendar) -> String? {
+    chineseLunarDate(from: date, calendar: gregorianCalendar)?.fullText
+}
+
+/// Convert a lunar day number (1-30) to Chinese numerals.
+private func chineseDayName(day: Int) -> String {
+    switch day {
+    case 1: return "初一"
+    case 2: return "初二"
+    case 3: return "初三"
+    case 4: return "初四"
+    case 5: return "初五"
+    case 6: return "初六"
+    case 7: return "初七"
+    case 8: return "初八"
+    case 9: return "初九"
+    case 10: return "初十"
+    case 11: return "十一"
+    case 12: return "十二"
+    case 13: return "十三"
+    case 14: return "十四"
+    case 15: return "十五"
+    case 16: return "十六"
+    case 17: return "十七"
+    case 18: return "十八"
+    case 19: return "十九"
+    case 20: return "二十"
+    case 21: return "廿一"
+    case 22: return "廿二"
+    case 23: return "廿三"
+    case 24: return "廿四"
+    case 25: return "廿五"
+    case 26: return "廿六"
+    case 27: return "廿七"
+    case 28: return "廿八"
+    case 29: return "廿九"
+    case 30: return "三十"
+    default: return ""
+    }
+}
+
+/// Convert a lunar month number (1-12) to Chinese month name.
+private func chineseMonthName(month: Int, isLeapMonth: Bool) -> String {
+    let monthNames = ["正月", "二月", "三月", "四月", "五月", "六月",
+                      "七月", "八月", "九月", "十月", "冬月", "腊月"]
+    
+    guard month >= 1 && month <= 12 else {
+        return ""
+    }
+    
+    let monthName = monthNames[month - 1]
+    return isLeapMonth ? "闰\(monthName)" : monthName
+}

--- a/CalendrTests/ChineseLunarCalendarTests.swift
+++ b/CalendrTests/ChineseLunarCalendarTests.swift
@@ -1,0 +1,119 @@
+//
+//  ChineseLunarCalendarTests.swift
+//  CalendrTests
+//
+//  Created by Paker on 28/08/2026.
+//
+
+import Foundation
+import Testing
+@testable import Calendr
+
+@Suite class ChineseLunarCalendarTests {
+    
+    let calendar = Calendar(identifier: .gregorian)
+    
+    @Test func testLunarDayFormatting() {
+        // Test various known dates and their lunar equivalents
+        // 2026-02-17 is the first day of the Chinese New Year (Year of the Horse)
+        let date1: Date = .make(year: 2026, month: 2, day: 17)
+        let lunar1 = chineseLunarDateString(from: date1, calendar: calendar)
+        #expect(lunar1 == "正月") // First day of first month shows month name
+        
+        // 2026-02-18 is the second day of the first lunar month
+        let date2: Date = .make(year: 2026, month: 2, day: 18)
+        let lunar2 = chineseLunarDateString(from: date2, calendar: calendar)
+        #expect(lunar2 == "初二")
+        
+        // 2026-02-26 is the tenth day of the first lunar month
+        let date3: Date = .make(year: 2026, month: 2, day: 26)
+        let lunar3 = chineseLunarDateString(from: date3, calendar: calendar)
+        #expect(lunar3 == "初十")
+        
+        // 2026-03-08 is the twentieth day of the first lunar month
+        let date4: Date = .make(year: 2026, month: 3, day: 8)
+        let lunar4 = chineseLunarDateString(from: date4, calendar: calendar)
+        #expect(lunar4 == "二十")
+    }
+    
+    @Test func testLunarMonthNames() {
+        // Test the first day of different lunar months
+        // 2026-03-19 is the first day of the second lunar month
+        let date1: Date = .make(year: 2026, month: 3, day: 19)
+        let lunar1 = chineseLunarDateString(from: date1, calendar: calendar)
+        #expect(lunar1 == "二月")
+        
+        // 2026-04-17 is the first day of the third lunar month
+        let date2: Date = .make(year: 2026, month: 4, day: 17)
+        let lunar2 = chineseLunarDateString(from: date2, calendar: calendar)
+        #expect(lunar2 == "三月")
+    }
+    
+    @Test func testLeapMonthFormatting() {
+        // 2023 has a leap second month (闰二月)
+        // 2023-03-22 is the first day of the leap second month
+        let date: Date = .make(year: 2023, month: 3, day: 22)
+        let lunar = chineseLunarDateString(from: date, calendar: calendar)
+        #expect(lunar == "闰二月")
+    }
+    
+    @Test func testLunarCalendarInViewModel() {
+        let date: Date = .make(year: 2026, month: 2, day: 17)
+        
+        // Test with showLunarCalendar = true
+        let vm1 = CalendarCellViewModel(
+            date: date,
+            inMonth: true,
+            isToday: false,
+            isSelected: false,
+            isHovered: false,
+            events: [],
+            dotsStyle: .none,
+            calendar: calendar,
+            showLunarCalendar: true,
+            showMainlandHolidays: false,
+            showSolarTerms: false
+        )
+        #expect(vm1.lunarText == "正月")
+        
+        // Test with showLunarCalendar = false
+        let vm2 = CalendarCellViewModel(
+            date: date,
+            inMonth: true,
+            isToday: false,
+            isSelected: false,
+            isHovered: false,
+            events: [],
+            dotsStyle: .none,
+            calendar: calendar,
+            showLunarCalendar: false,
+            showMainlandHolidays: false,
+            showSolarTerms: false
+        )
+        #expect(vm2.lunarText == nil)
+    }
+    
+    @Test func testGregorianDayNumberFormat() {
+        let date: Date = .make(year: 2026, month: 2, day: 17)
+        
+        let vm = CalendarCellViewModel(
+            date: date,
+            inMonth: true,
+            isToday: false,
+            isSelected: false,
+            isHovered: false,
+            events: [],
+            dotsStyle: .none,
+            calendar: calendar,
+            showLunarCalendar: true,
+            showMainlandHolidays: false,
+            showSolarTerms: false
+        )
+        
+        // Gregorian day should still be 17
+        #expect(vm.text == "17")
+        
+        // Lunar date should be the month name
+        #expect(vm.lunarText == "正月")
+    }
+}


### PR DESCRIPTION
Hey! Following up on [imboni/Calendr#1](https://github.com/imboni/Calendr/pull/1).

This adds lunar dates (on the grid and in the menu bar), mainland holidays, and solar terms. They're everyday stuff for Chinese users, and each one has a setting so people can turn it off. When they're off, the grid goes back to the original layout.

I left out the year/month pickers. Those are just something I added for myself, not a Chinese-calendar thing.

Most of this was written with AI help.