### PR TITLE
Add Chinese holidays support

### DIFF
--- a/Calendr/Calendar/CalendarCellViewModel.swift
+++ b/Calendr/Calendar/CalendarCellViewModel.swift
@@ -36,7 +36,7 @@ extension CalendarCellViewModel {
     }
 
     var textColor: NSColor {
-        isHoliday ? .systemRed : .headerTextColor
+        isHoliday && plugin?.replaceHoliday != true ? .systemRed : .headerTextColor
     }
 
     var borderColor: NSColor {

--- a/Calendr/Calendar/CalendarViewModel.swift
+++ b/Calendr/Calendar/CalendarViewModel.swift
@@ -85,9 +85,8 @@ class CalendarViewModel {
                 dateRangeObservable,
                 calendarUpdated,
                 settings.eventDotsStyle,
-                settings.showLunarCalendar
             )
-            .map { weeksCount, month, calendar, dotsStyle, showLunarCalendar -> [CalendarCellViewModel] in
+            .map { weeksCount, month, calendar, dotsStyle -> [CalendarCellViewModel] in
 
                 let monthStartWeekDay = calendar.component(.weekday, from: month.start)
 
@@ -101,10 +100,6 @@ class CalendarViewModel {
                     let date = calendar.date(byAdding: .day, value: day, to: start)!
                     let inMonth = calendar.isDate(date, equalTo: month.start, toGranularity: .month)
 
-                    let plugin: (any CalendarCellPlugin)? = showLunarCalendar
-                        ? ChineseCalendarCellPlugin(for: date)
-                        : nil
-
                     return CalendarCellViewModel(
                         date: date,
                         inMonth: inMonth,
@@ -115,7 +110,7 @@ class CalendarViewModel {
                         isHoliday: false,
                         dotsStyle: dotsStyle,
                         calendar: calendar,
-                        plugin: plugin?.eraseToAnyPlugin()
+                        plugin: nil
                     )
                 }
             }
@@ -209,6 +204,45 @@ class CalendarViewModel {
         .distinctUntilChanged()
         .share(replay: 1)
 
+        // Apply plugins
+        let cellsWithPlugins = Observable.combineLatest(
+            cellsWithHolidays,
+            eventsObservable,
+            settings.showLunarCalendar
+        )
+        .map {
+            cellViewModels,
+            events,
+            showLunarCalendar -> [CalendarCellViewModel] in
+
+            cellViewModels.map { vm in
+
+                let events = events.filter {
+                    dateProvider.calendar.isDay(vm.date, inDays: ($0.start, $0.end))
+                }
+
+                let plugin: (any CalendarCellPlugin)? = {
+                    if showLunarCalendar {
+                        return ChineseCalendarCellPlugin(
+                            for: vm.date,
+                            isHoliday: vm.isHoliday,
+                            events: events.map(\.title)
+                        )
+                    }
+                    return nil
+                }()
+
+                guard let plugin else {
+                    return vm
+                }
+                return vm.with(
+                    plugin: plugin.eraseToAnyPlugin(),
+                )
+            }
+        }
+        .distinctUntilChanged()
+        .share(replay: 1)
+
         var timeZone = dateProvider.calendar.timeZone
 
         // Check if today has changed
@@ -225,7 +259,7 @@ class CalendarViewModel {
 
         // Check which cell is today
         let cellsWithIsToday = Observable.combineLatest(
-            cellsWithHolidays, todayObservable
+            cellsWithPlugins, todayObservable
         )
         .map { cellViewModels, today -> [CalendarCellViewModel] in
 
@@ -395,7 +429,8 @@ private extension CalendarCellViewModel {
         isHovered: Bool? = nil,
         events: [EventModel]? = nil,
         isHoliday: Bool? = nil,
-        calendar: Calendar? = nil
+        calendar: Calendar? = nil,
+        plugin: AnyCalendarCellPlugin? = nil
     ) -> Self {
 
         CalendarCellViewModel(
@@ -408,7 +443,7 @@ private extension CalendarCellViewModel {
             isHoliday: isHoliday ?? self.isHoliday,
             dotsStyle: dotsStyle,
             calendar: calendar ?? self.calendar,
-            plugin: plugin
+            plugin: plugin ?? self.plugin
         )
     }
 }

--- a/Calendr/Calendar/Plugins/CalendarCellPlugin.swift
+++ b/Calendr/Calendar/Plugins/CalendarCellPlugin.swift
@@ -12,6 +12,8 @@ protocol CalendarCellPlugin: Equatable {
     var textColor: NSColor? { get }
     var font: NSFont? { get }
     var spacing: CGFloat? { get }
+    /// prevents default holiday highlight
+    var replaceHoliday: Bool { get }
 }
 
 extension CalendarCellPlugin {
@@ -19,6 +21,7 @@ extension CalendarCellPlugin {
     var textColor: NSColor? { nil }
     var font: NSFont? { nil }
     var spacing: CGFloat? { nil }
+    var replaceHoliday: Bool { false }
 }
 
 struct AnyCalendarCellPlugin: CalendarCellPlugin {
@@ -26,6 +29,7 @@ struct AnyCalendarCellPlugin: CalendarCellPlugin {
     let textColor: NSColor?
     let font: NSFont?
     let spacing: CGFloat?
+    let replaceHoliday: Bool
 }
 
 extension CalendarCellPlugin {
@@ -35,7 +39,8 @@ extension CalendarCellPlugin {
             text: text,
             textColor: textColor,
             font: font,
-            spacing: spacing
+            spacing: spacing,
+            replaceHoliday: replaceHoliday
         )
     }
 }

--- a/Calendr/Calendar/Plugins/Chinese/CalendarCellPlugin+Chinese.swift
+++ b/Calendr/Calendar/Plugins/Chinese/CalendarCellPlugin+Chinese.swift
@@ -8,31 +8,40 @@
 import AppKit
 
 struct ChineseCalendarCellPlugin: CalendarCellPlugin {
-    let text: String?
-    let textColor: NSColor?
-    let font: NSFont?
+    private(set) var text: String?
+    private(set) var textColor: NSColor?
+    private(set) var font: NSFont?
+
+    let replaceHoliday = true
     let spacing: CGFloat? = 1
 
-    init(for date: Date) {
+    init(for date: Date, isHoliday: Bool, events: [String]) {
 
-        let lunarDate = ChineseLunarDate(from: date)
-        let solarTerm = ChineseSolarTerm(from: date)
-
-        let isMonthStart = lunarDate?.isMonthStart == true
-
-        text = solarTerm?.text ?? lunarDate?.text
-
-        textColor = solarTerm != nil
-        ? .systemBrown.withAlphaComponent(0.85)
-        : isMonthStart
-        ? .labelColor
-        : .secondaryLabelColor
+        guard let lunarDate = ChineseLunarDate(from: date) else { return }
 
         font = .systemFont(
-            ofSize: 9,
-            weight: isMonthStart ? .semibold : .regular
+            ofSize: Contants.fontSize,
+            weight: lunarDate.isMonthStart ? .semibold : .regular
         )
+
+        if isHoliday, let holiday = events.firstNonNil(ChineseHoliday.init) {
+            text = holiday.text
+            textColor = .systemRed
+        }
+        else if let solarTerm = ChineseSolarTerm(from: date) {
+            text = solarTerm.text
+            textColor = .systemBrown.withAlphaComponent(0.85)
+        }
+        else {
+            text = lunarDate.text
+            textColor = .secondaryLabelColor
+        }
     }
 
     static let cellSize: CGSize = .init(width: 30, height: 38)
+}
+
+private enum Contants {
+
+    static let fontSize: CGFloat = 9
 }

--- a/Calendr/Calendar/Plugins/Chinese/ChineseHoliday.swift
+++ b/Calendr/Calendar/Plugins/Chinese/ChineseHoliday.swift
@@ -1,0 +1,35 @@
+//
+//  ChineseHoliday.swift
+//  Calendr
+//
+//  Created by Paker on 02/09/2026.
+//
+
+struct ChineseHoliday: Equatable {
+    let text: String
+
+    init?(from title: String) {
+        guard
+            !title.contains("班"), // exclude make-up workdays
+            let short = shortHolidayMapping.first(where: { title.contains($0.key) })
+        else {
+            return nil
+        }
+
+        self.text = short.value
+    }
+}
+
+/// Lookup table for Chinese holidays.
+/// Maps terms included in titles to 2-3 character short strings.
+private let shortHolidayMapping: [String: String] = [
+    // ------------------------------------------- 2026 ----- //
+    "元旦": "元旦",      // New Year's Day          January 1
+    "除夕": "除夕",      // Chinese New Year's Eve  February 16
+    "春节": "春节",      // Spring Festival         February 17
+    "清明": "清明",      // Tomb-Sweeping Day       April 5
+    "劳动": "劳动节",    // Labor Day                May 1
+    "端午": "端午节",    // Dragon Boat Festival     June 19
+    "中秋": "中秋节",    // Mid-Autumn Festival      September 25
+    "国庆": "国庆节",    // National Day             October 1
+]

--- a/Calendr/Calendar/Plugins/Chinese/ChineseLunarDate.swift
+++ b/Calendr/Calendar/Plugins/Chinese/ChineseLunarDate.swift
@@ -32,60 +32,36 @@ extension ChineseLunarDate {
         let monthName = chineseMonthName(month: month, isLeapMonth: isLeapMonth)
         let dayName = chineseDayName(day: day)
 
+        self.fullText = monthName + dayName
+
         if day == 1 {
-            self.init(text: monthName, fullText: monthName + dayName, isMonthStart: true)
+            self.text = monthName
+            self.isMonthStart = true
         } else {
-            self.init(text: dayName, fullText: monthName + dayName, isMonthStart: false)
+            self.text = dayName
+            self.isMonthStart = false
         }
     }
 }
 
+private let monthNames = [
+    "正月", "二月", "三月", "四月", "五月", "六月",
+    "七月", "八月", "九月", "十月", "冬月", "腊月"
+]
+
+private let dayNames = [
+    "初一", "初二", "初三", "初四", "初五", "初六", "初七", "初八", "初九", "初十",
+    "十一", "十二", "十三", "十四", "十五", "十六", "十七", "十八", "十九", "二十",
+    "廿一", "廿二", "廿三", "廿四", "廿五", "廿六", "廿七", "廿八", "廿九", "三十"
+]
+
 /// Convert a lunar day number (1-30) to Chinese numerals.
 private func chineseDayName(day: Int) -> String {
-    switch day {
-    case 1: return "初一"
-    case 2: return "初二"
-    case 3: return "初三"
-    case 4: return "初四"
-    case 5: return "初五"
-    case 6: return "初六"
-    case 7: return "初七"
-    case 8: return "初八"
-    case 9: return "初九"
-    case 10: return "初十"
-    case 11: return "十一"
-    case 12: return "十二"
-    case 13: return "十三"
-    case 14: return "十四"
-    case 15: return "十五"
-    case 16: return "十六"
-    case 17: return "十七"
-    case 18: return "十八"
-    case 19: return "十九"
-    case 20: return "二十"
-    case 21: return "廿一"
-    case 22: return "廿二"
-    case 23: return "廿三"
-    case 24: return "廿四"
-    case 25: return "廿五"
-    case 26: return "廿六"
-    case 27: return "廿七"
-    case 28: return "廿八"
-    case 29: return "廿九"
-    case 30: return "三十"
-    default: return ""
-    }
+    dayNames[day - 1]
 }
 
 /// Convert a lunar month number (1-12) to Chinese month name.
 private func chineseMonthName(month: Int, isLeapMonth: Bool) -> String {
-    let monthNames = ["正月", "二月", "三月", "四月", "五月", "六月",
-                      "七月", "八月", "九月", "十月", "冬月", "腊月"]
-    
-    guard month >= 1 && month <= 12 else {
-        return ""
-    }
-    
     let monthName = monthNames[month - 1]
     return isLeapMonth ? "闰\(monthName)" : monthName
 }

--- a/Calendr/Calendar/Plugins/Chinese/ChineseSolarTerm.swift
+++ b/Calendr/Calendar/Plugins/Chinese/ChineseSolarTerm.swift
@@ -28,11 +28,13 @@ extension ChineseSolarTerm {
         let year = shanghaiCalendar.component(.year, from: date)
         for yearToCheck in [year - 1, year] {
             for index in solarTermNames.indices {
-                guard let termDate = dateOfSolarTerm(year: yearToCheck, index: index) else { continue }
-                if shanghaiCalendar.isDate(date, inSameDayAs: termDate) {
-                    self.init(text: solarTermNames[index])
-                    return
-                }
+                guard
+                    let termDate = dateOfSolarTerm(year: yearToCheck, index: index),
+                    shanghaiCalendar.isDate(date, inSameDayAs: termDate)
+                else { continue }
+
+                self.text = solarTermNames[index]
+                return
             }
         }
         return nil

--- a/Calendr/Extensions/Collection.swift
+++ b/Calendr/Extensions/Collection.swift
@@ -52,4 +52,13 @@ extension Collection {
         }
         return result
     }
+
+    func firstNonNil<T>(_ transform: (Element) throws -> T?) rethrows -> T? {
+        for value in self {
+            if let value = try transform(value) {
+                return value
+            }
+        }
+        return nil
+    }
 }

--- a/Calendr/Mocks/MockCalendarSettings.swift
+++ b/Calendr/Mocks/MockCalendarSettings.swift
@@ -69,7 +69,7 @@ class MockCalendarSettings: CalendarSettings {
         highlightedWeekdays: [Int] = [0, 6],
         showMonthOutline: Bool = false,
         showWeekNumbers: Bool = false,
-        showLunarCalendar: Bool = true,
+        showLunarCalendar: Bool = false,
         holidayCalendars: [String] = [],
         weekCount: Int = 6,
         eventDotsStyle: EventDotsStyle = .multiple,

--- a/CalendrTests/ChineseLunarCalendarTests.swift
+++ b/CalendrTests/ChineseLunarCalendarTests.swift
@@ -6,6 +6,7 @@
 //  Authored by Boni (imboni)
 //
 
+import AppKit
 import Foundation
 import Testing
 @testable import Calendr
@@ -95,12 +96,104 @@ import Testing
         #expect(plugin.text == "雨水")
     }
 
-    private func makePlugin(for date: Date) -> ChineseCalendarCellPlugin {
-        ChineseCalendarCellPlugin(for: date)
+    @Test(arguments: [
+        ("元旦", "元旦"),
+        ("除夕", "除夕"),
+        ("春节", "春节"),
+        ("春节假期", "春节"),
+        ("清明", "清明"),
+        ("清明节", "清明"),
+        ("劳动", "劳动节"),
+        ("劳动节", "劳动节"),
+        ("端午", "端午节"),
+        ("端午节", "端午节"),
+        ("中秋", "中秋节"),
+        ("中秋节", "中秋节"),
+        ("国庆", "国庆节"),
+        ("国庆节", "国庆节"),
+    ])
+    func testHolidayMapping(_ title: String, _ expected: String) {
+        #expect(ChineseHoliday(from: title)?.text == expected)
     }
 
-    private func makeViewModel(for date: Date) -> CalendarCellViewModel {
-        let plugin = makePlugin(for: date)
+    @Test(arguments: [
+        "",
+        "圣诞节",
+        "Holiday",
+        "春节补班",
+        "国庆节调休上班",
+        "班",
+    ])
+    func testHolidayMapping_returnsNil(_ title: String) {
+        #expect(ChineseHoliday(from: title) == nil)
+    }
+
+    @Test func testHolidayShouldSupersedeLunarDay() {
+        // 2026-02-17 is Chinese New Year (正月)
+        let date: Date = .make(year: 2026, month: 2, day: 17)
+
+        let plugin = makePlugin(for: date, isHoliday: true, events: ["春节"])
+        #expect(plugin.text == "春节")
+        #expect(plugin.textColor == .systemRed)
+    }
+
+    @Test func testHolidayShouldSupersedeSolarTerm() {
+        // 2026-02-18 is 雨水
+        let date: Date = .make(year: 2026, month: 2, day: 18)
+
+        let plugin = makePlugin(for: date, isHoliday: true, events: ["春节"])
+        #expect(plugin.text == "春节")
+        #expect(plugin.textColor == .systemRed)
+    }
+
+    @Test func testHolidayIgnoredWhenCellIsNotHoliday() {
+        let date: Date = .make(year: 2026, month: 2, day: 17)
+
+        let plugin = makePlugin(for: date, isHoliday: false, events: ["春节"])
+        #expect(plugin.text == "正月")
+        #expect(plugin.textColor == .secondaryLabelColor)
+    }
+
+    @Test func testHolidayIgnoredWhenEventsDoNotMatch() {
+        let date: Date = .make(year: 2026, month: 2, day: 17)
+
+        let plugin = makePlugin(for: date, isHoliday: true, events: ["Some event"])
+        #expect(plugin.text == "正月")
+    }
+
+    @Test func testHolidayUsesFirstMatchingEvent() {
+        let date: Date = .make(year: 2026, month: 2, day: 17)
+
+        let plugin = makePlugin(for: date, isHoliday: true, events: ["Meeting", "春节补班", "春节", "元旦"])
+        #expect(plugin.text == "春节")
+    }
+
+    @Test func testHolidayPlugin_doesNotHighlightGregorianDay() {
+        let date: Date = .make(year: 2026, month: 2, day: 17)
+
+        let vm = makeViewModel(for: date, isHoliday: true, events: ["春节"])
+
+        #expect(vm.text == "17")
+        #expect(vm.textColor == .headerTextColor)
+        #expect(vm.plugin?.text == "春节")
+        #expect(vm.plugin?.textColor == .systemRed)
+        #expect(vm.plugin?.replaceHoliday == true)
+    }
+
+    private func makePlugin(
+        for date: Date,
+        isHoliday: Bool = false,
+        events: [String] = []
+    ) -> ChineseCalendarCellPlugin {
+        ChineseCalendarCellPlugin(for: date, isHoliday: isHoliday, events: events)
+    }
+
+    private func makeViewModel(
+        for date: Date,
+        isHoliday: Bool = false,
+        events: [String] = []
+    ) -> CalendarCellViewModel {
+        let plugin = makePlugin(for: date, isHoliday: isHoliday, events: events)
         return CalendarCellViewModel(
             date: date,
             inMonth: true,
@@ -108,7 +201,7 @@ import Testing
             isSelected: false,
             isHovered: false,
             events: [],
-            isHoliday: false,
+            isHoliday: isHoliday,
             dotsStyle: .none,
             calendar: calendar,
             plugin: plugin.eraseToAnyPlugin()


### PR DESCRIPTION
This requires a calendar to be set as a holiday calendar in the app settings.

Known holiday names will then be sourced from that calendar,
converted to a short text (2-3 chars), and displayed over the lunar dates.

Non-Chinese holidays will not be highlighted when the lunar calendar is enabled.

This is very much inspired by @imboni's implementation, but only considering statutory holidays for simplification.

You can check his fork in https://github.com/imboni/Calendr

Close #771 