### PR TITLE
Prevent displaying Chinese holiday from regular calendar

### DIFF
--- a/Calendr/Calendar/CalendarViewModel.swift
+++ b/Calendr/Calendar/CalendarViewModel.swift
@@ -184,19 +184,27 @@ class CalendarViewModel {
         .distinctUntilChanged()
         .share(replay: 1)
 
-        // Check which cells are holidays
-        let cellsWithHolidays = Observable.combineLatest(
-            dateCellsObservable,
+        let holidayEventsObservable = Observable.combineLatest(
             eventsObservable,
             settings.holidayCalendars
         )
-        .map { cellViewModels, events, holidayCalendars -> [CalendarCellViewModel] in
+        .map { events, holidayCalendars in
+            events.filter { holidayCalendars.contains($0.calendar.id) }
+        }
+        .distinctUntilChanged()
+        .share(replay: 1)
+
+        // Check which cells are holidays
+        let cellsWithHolidays = Observable.combineLatest(
+            dateCellsObservable,
+            holidayEventsObservable
+        )
+        .map { cellViewModels, holidays -> [CalendarCellViewModel] in
 
             cellViewModels.map { vm in
                 vm.with(
-                    isHoliday: events.contains { event in
-                        holidayCalendars.contains(event.calendar.id)
-                        && dateProvider.calendar.isDay(vm.date, inDays: (event.start, event.end))
+                    isHoliday: holidays.contains { event in
+                        dateProvider.calendar.isDay(vm.date, inDays: (event.start, event.end))
                     }
                 )
             }
@@ -207,17 +215,17 @@ class CalendarViewModel {
         // Apply plugins
         let cellsWithPlugins = Observable.combineLatest(
             cellsWithHolidays,
-            eventsObservable,
+            holidayEventsObservable,
             settings.showLunarCalendar
         )
         .map {
             cellViewModels,
-            events,
+            holidays,
             showLunarCalendar -> [CalendarCellViewModel] in
 
             cellViewModels.map { vm in
 
-                let events = events.filter {
+                let dateHolidays = holidays.filter {
                     dateProvider.calendar.isDay(vm.date, inDays: ($0.start, $0.end))
                 }
 
@@ -225,8 +233,7 @@ class CalendarViewModel {
                     if showLunarCalendar {
                         return ChineseCalendarCellPlugin(
                             for: vm.date,
-                            isHoliday: vm.isHoliday,
-                            events: events.map(\.title)
+                            holidays: dateHolidays.map(\.title)
                         )
                     }
                     return nil

--- a/Calendr/Calendar/Plugins/Chinese/CalendarCellPlugin+Chinese.swift
+++ b/Calendr/Calendar/Plugins/Chinese/CalendarCellPlugin+Chinese.swift
@@ -15,7 +15,7 @@ struct ChineseCalendarCellPlugin: CalendarCellPlugin {
     let replaceHoliday = true
     let spacing: CGFloat? = 1
 
-    init(for date: Date, isHoliday: Bool, events: [String]) {
+    init(for date: Date, holidays: [String]) {
 
         guard let lunarDate = ChineseLunarDate(from: date) else { return }
 
@@ -24,7 +24,7 @@ struct ChineseCalendarCellPlugin: CalendarCellPlugin {
             weight: lunarDate.isMonthStart ? .semibold : .regular
         )
 
-        if isHoliday, let holiday = events.firstNonNil(ChineseHoliday.init) {
+        if let holiday = holidays.firstNonNil(ChineseHoliday.init) {
             text = holiday.text
             textColor = .systemRed
         }

--- a/CalendrTests/ChineseLunarCalendarTests.swift
+++ b/CalendrTests/ChineseLunarCalendarTests.swift
@@ -132,7 +132,7 @@ import Testing
         // 2026-02-17 is Chinese New Year (正月)
         let date: Date = .make(year: 2026, month: 2, day: 17)
 
-        let plugin = makePlugin(for: date, isHoliday: true, events: ["春节"])
+        let plugin = makePlugin(for: date, holidays: ["春节"])
         #expect(plugin.text == "春节")
         #expect(plugin.textColor == .systemRed)
     }
@@ -141,37 +141,45 @@ import Testing
         // 2026-02-18 is 雨水
         let date: Date = .make(year: 2026, month: 2, day: 18)
 
-        let plugin = makePlugin(for: date, isHoliday: true, events: ["春节"])
+        let plugin = makePlugin(for: date, holidays: ["春节"])
         #expect(plugin.text == "春节")
         #expect(plugin.textColor == .systemRed)
-    }
-
-    @Test func testHolidayIgnoredWhenCellIsNotHoliday() {
-        let date: Date = .make(year: 2026, month: 2, day: 17)
-
-        let plugin = makePlugin(for: date, isHoliday: false, events: ["春节"])
-        #expect(plugin.text == "正月")
-        #expect(plugin.textColor == .secondaryLabelColor)
     }
 
     @Test func testHolidayIgnoredWhenEventsDoNotMatch() {
         let date: Date = .make(year: 2026, month: 2, day: 17)
 
-        let plugin = makePlugin(for: date, isHoliday: true, events: ["Some event"])
+        let plugin = makePlugin(for: date, holidays: ["Some holiday"])
         #expect(plugin.text == "正月")
     }
 
     @Test func testHolidayUsesFirstMatchingEvent() {
         let date: Date = .make(year: 2026, month: 2, day: 17)
 
-        let plugin = makePlugin(for: date, isHoliday: true, events: ["Meeting", "春节补班", "春节", "元旦"])
+        let plugin = makePlugin(for: date, holidays: ["Meeting", "春节补班", "春节", "元旦"])
         #expect(plugin.text == "春节")
+    }
+
+    @Test func testHolidayPlugin_withChineseHolidayFromRegularCalendar_shouldNotDisplayChineseHoliday() {
+        let date: Date = .make(year: 2026, month: 2, day: 17)
+
+        let plugin = makeViewModel(for: date, events: ["春节"])
+        #expect(plugin.plugin?.text == "正月")
+        #expect(plugin.plugin?.textColor == .secondaryLabelColor)
+    }
+
+    @Test func testHolidayPlugin_withChineseHolidayFromRegularCalendar_withGregorianHoliday_shouldNotDisplayChineseHoliday() {
+        let date: Date = .make(year: 2026, month: 2, day: 17)
+
+        let plugin = makeViewModel(for: date, events: ["春节"], holidays: ["Holiday"])
+        #expect(plugin.plugin?.text == "正月")
+        #expect(plugin.plugin?.textColor == .secondaryLabelColor)
     }
 
     @Test func testHolidayPlugin_doesNotHighlightGregorianDay() {
         let date: Date = .make(year: 2026, month: 2, day: 17)
 
-        let vm = makeViewModel(for: date, isHoliday: true, events: ["春节"])
+        let vm = makeViewModel(for: date, holidays: ["春节"])
 
         #expect(vm.text == "17")
         #expect(vm.textColor == .headerTextColor)
@@ -182,29 +190,30 @@ import Testing
 
     private func makePlugin(
         for date: Date,
-        isHoliday: Bool = false,
-        events: [String] = []
+        holidays: [String] = []
     ) -> ChineseCalendarCellPlugin {
-        ChineseCalendarCellPlugin(for: date, isHoliday: isHoliday, events: events)
+        ChineseCalendarCellPlugin(for: date, holidays: holidays)
     }
 
     private func makeViewModel(
         for date: Date,
-        isHoliday: Bool = false,
-        events: [String] = []
+        events: [String] = [],
+        holidays: [String] = []
     ) -> CalendarCellViewModel {
-        let plugin = makePlugin(for: date, isHoliday: isHoliday, events: events)
-        return CalendarCellViewModel(
+        .init(
             date: date,
             inMonth: true,
             isToday: false,
             isSelected: false,
             isHovered: false,
-            events: [],
-            isHoliday: isHoliday,
+            events: events.map { .make(title: $0) },
+            isHoliday: !holidays.isEmpty,
             dotsStyle: .none,
             calendar: calendar,
-            plugin: plugin.eraseToAnyPlugin()
+            plugin: ChineseCalendarCellPlugin(
+                for: date,
+                holidays: holidays
+            ).eraseToAnyPlugin()
         )
     }
 }


### PR DESCRIPTION
A Chinese holiday from a source not marked as a holiday calendar could be displayed in the presence of an event from an unrelated holiday calendar.