### PR TITLE
Check if network response is success

### DIFF
--- a/Calendr/Providers/NetworkServiceProvider.swift
+++ b/Calendr/Providers/NetworkServiceProvider.swift
@@ -21,12 +21,20 @@ class NetworkServiceProvider: NetworkServiceProviding {
     }
 
     func data(from url: URL) async throws -> Data {
-        let (data, _) = try await session.data(from: url)
+        let (data, response) = try await session.data(from: url)
+        try assertSuccess(response)
         return data
     }
 
     func download(from url: URL) async throws -> URL {
-        let (url, _) = try await session.download(from: url)
+        let (url, response) = try await session.download(from: url)
+        try assertSuccess(response)
         return url
+    }
+}
+
+private func assertSuccess(_ response: URLResponse) throws {
+    guard let http = response as? HTTPURLResponse, http.statusCode == 200 else {
+        throw URLError(.badServerResponse)
     }
 }


### PR DESCRIPTION
Follow-up on:
- #787

A missing thumbnail returns `404` with a placeholder image.

For all use cases in this app we only care about `200`.