### PR TITLE
Fix master never writing to cache

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -35,7 +35,9 @@ jobs:
         uses: actions/cache@v6
         with:
           path: .build
-          key: ${{ runner.os }}-spm-${{ hashFiles('Package.resolved') }}
+          key: ${{ runner.os }}-spm-${{ hashFiles('Package.resolved') }}-${{ github.event.pull_request.base.sha || github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-spm-${{ hashFiles('Package.resolved') }}-
 
       - name: Test
         run: |


### PR DESCRIPTION
Always write to cache on master. PRs only when dependencies change.
Fallback to latest cache from master with same dependencies in case master has not finished writing the cache for a brand-new commit.