### PR TITLE
Clean merged PR caches on master

### DIFF
--- a/.github/workflows/clean-up-caches.yml
+++ b/.github/workflows/clean-up-caches.yml
@@ -1,8 +1,8 @@
 name: Cleanup
 
 on:
-  pull_request:
-    types: [closed]
+  push:
+    branches: [master]
 
 permissions:
   actions: write
@@ -15,9 +15,12 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPOSITORY: ${{ github.repository }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
-          gh cache delete \
-          --repo ${REPOSITORY} \
-          --ref "refs/pull/${PR_NUMBER}/merge" \
-          --all --succeed-on-no-caches
+          PR_NUMBERS=$(gh pr list --state closed --limit 100 --json number,closedAt | jq -r '. | sort_by(.closedAt) | .[-5:] | .[].number')
+
+          for PR_NUMBER in $PR_NUMBERS; do
+            gh cache delete \
+              --repo ${REPOSITORY} \
+              --ref "refs/pull/${PR_NUMBER}/merge" \
+              --all --succeed-on-no-caches
+          done


### PR DESCRIPTION
Running this from fork PRs caused two issues:
1. I have to go back to the merged PR and approve the workflow
2. The PR has permission to create caches but not to delete them

The solution is to run this after merge, in the upstream context (master).